### PR TITLE
docs: resolve 3 High findings on M1 specs (2nd /audit-doc)

### DIFF
--- a/docs/specs/m1/spec-01-testcontainers-and-integration-tests.md
+++ b/docs/specs/m1/spec-01-testcontainers-and-integration-tests.md
@@ -90,7 +90,33 @@ public class TestcontainersConfig {
 - Neo4j 이미지 태그는 docker-compose.yml의 프로덕션 버전과 일치시킬 것 (확인 후 교체)
 - `.withReuse(true)`로 테스트 간 컨테이너 재사용하여 속도 확보 (로컬 한정)
 
-### (3) CI 워크플로우에 테스트 단계 추가
+### (3) `application-test.yml` 뼈대 생성
+
+Task 1.4의 N+1 테스트가 Hibernate `Statistics` API에 의존하므로, 해당 설정을 이 spec에서 뼈대 형태로 먼저 생성한다. 피처 플래그·관측성·벤치마크 baseline은 Spec 03 Task 3.1에서 확장된다.
+
+위치: `api/src/main/resources/application-test.yml`
+
+```yaml
+# 테스트 전용 프로파일 뼈대. securelocal과 독립적이며 인클루드 관계 없음.
+# 활성화: @ActiveProfiles("test") 또는 -Dspring.profiles.active=test
+# 이 파일은 Spec 03 Task 3.1에서 mmt.* 설정과 benchmark baseline이 추가되어 확장됨.
+
+spring:
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true   # Task 1.4의 N+1 테스트가 이 설정에 의존
+        format_sql: true
+    show-sql: false  # 로그는 logging.level로 제어
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE  # Hibernate 6.x (Spring Boot 3.x)
+    org.springframework.data.neo4j.cypher: DEBUG
+```
+
+### (4) CI 워크플로우에 테스트 단계 추가
 
 `.github/workflows/api-ci-cd-with-ec2.yml`에 기존 Docker build 이전에 테스트 단계 삽입:
 
@@ -127,6 +153,7 @@ jobs:
 **산출물:**
 - [ ] `api/build.gradle` 업데이트 (Testcontainers BOM + MySQL + Neo4j + JUnit Jupiter)
 - [ ] `api/src/test/java/com/mmt/api/config/TestcontainersConfig.java` 신규 (패키지는 실제 구조에 맞춰)
+- [ ] `api/src/main/resources/application-test.yml` 뼈대 생성 (Spec 03에서 확장)
 - [ ] `.github/workflows/api-ci-cd-with-ec2.yml`에 test 잡 추가
 
 **검증:**

--- a/docs/specs/m1/spec-02-performance-baseline.md
+++ b/docs/specs/m1/spec-02-performance-baseline.md
@@ -23,7 +23,7 @@ Neo4j → MySQL CTE 마이그레이션(M2) 전의 **성능 기준선을 실측**
 
 1. **수치는 실측**: 이 spec의 모든 성능 수치는 실측해서 기록한다. 원본 문서의 추측값(`~5ms` 등)은 **기준선으로 사용 금지**
 2. **측정 환경 기록**: JVM 옵션, 컨테이너 스펙, 테스트 데이터 규모를 모든 측정에 기록
-3. **반복 측정**: 각 쿼리는 최소 **warm-up 3회 + 측정 10회**로 평균·p95·p99 산출
+3. **반복 측정**: 각 쿼리는 최소 **warm-up 3회 + 측정 100회**로 평균·p95·p99 산출 (표본 10회는 p99가 사실상 최대값과 같아 통계적 의미가 없음 → 100회 필수)
 4. **커밋 분리**: 벤치마크 코드와 측정 결과 기록은 별도 커밋
 
 ---
@@ -79,7 +79,7 @@ class GraphQueryPerformanceTest {
     private ConceptService conceptService;
 
     private static final int WARMUP_RUNS = 3;
-    private static final int MEASURED_RUNS = 10;
+    private static final int MEASURED_RUNS = 100;  // p99 산출을 위해 100회 필수
 
     @Test
     void benchmarkDepth3GraphTraversal() {
@@ -129,15 +129,15 @@ class RepositoryBenchmarkTest {
 
         for (int i = 0; i < 3; i++) probabilityRepository.findResults(userTestId);
 
-        long[] nanos = new long[10];
-        for (int i = 0; i < 10; i++) {
+        long[] nanos = new long[100];
+        for (int i = 0; i < 100; i++) {
             long start = System.nanoTime();
             probabilityRepository.findResults(userTestId);
             nanos[i] = System.nanoTime() - start;
         }
 
         Arrays.sort(nanos);
-        long avgMs = Arrays.stream(nanos).sum() / 10 / 1_000_000;
+        long avgMs = Arrays.stream(nanos).sum() / 100 / 1_000_000;
         System.out.printf("[Benchmark] findResults: avg=%dms%n", avgMs);
     }
 }

--- a/docs/specs/m1/spec-03-feature-flags-and-observability.md
+++ b/docs/specs/m1/spec-03-feature-flags-and-observability.md
@@ -302,15 +302,32 @@ cd api && ./gradlew test --tests "*N1Test"
 
 **작업 내용:**
 
-### (1) AOP 의존성 추가
+### (1) AOP 의존성 및 MeterRegistry Bean 구성
+
+build.gradle에 AOP + Micrometer Core 의존성 추가:
 
 ```gradle
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
-    // Micrometer는 Spring Boot Actuator에 포함됨. 이미 있다면 스킵
     implementation 'io.micrometer:micrometer-core'
 }
 ```
+
+Actuator를 도입하지 않으므로 `MeterRegistry`는 자동 등록되지 않는다. 현재 용도(Aspect 내 Timer)에 맞춰 `SimpleMeterRegistry`를 수동 Bean으로 등록한다:
+
+```java
+// api/src/main/java/com/mmt/api/config/ObservabilityConfig.java (실제 패키지 구조에 맞춰)
+@Configuration
+public class ObservabilityConfig {
+
+    @Bean
+    public MeterRegistry meterRegistry() {
+        return new SimpleMeterRegistry();
+    }
+}
+```
+
+추후 Prometheus·Grafana 연동이 로드맵으로 진입하면 `spring-boot-starter-actuator`로 승급하고 이 Bean은 제거한다.
 
 ### (2) Aspect 클래스 작성
 
@@ -384,7 +401,8 @@ class QueryTimingAspectTest {
 ```
 
 **산출물:**
-- [ ] `spring-boot-starter-aop` 의존성 추가
+- [ ] `spring-boot-starter-aop` + `io.micrometer:micrometer-core` 의존성 추가
+- [ ] `ObservabilityConfig` (`SimpleMeterRegistry` Bean 수동 등록)
 - [ ] `QueryTimingAspect` 클래스
 - [ ] `QueryTimingAspectTest`
 

--- a/docs/specs/m1/spec-03-feature-flags-and-observability.md
+++ b/docs/specs/m1/spec-03-feature-flags-and-observability.md
@@ -53,28 +53,14 @@ mmt:
     slow-query-threshold-ms: 100
 ```
 
-### (2) `application-test.yml` 신규 생성
+### (2) `application-test.yml` 확장 (Spec 01 뼈대 위에 추가)
 
-위치: `api/src/main/resources/application-test.yml`
+Spec 01 Task 1.1 (3)에서 이미 `application-test.yml` 뼈대가 생성되어 `hibernate.generate_statistics`·SQL·Cypher 로깅은 포함되어 있다. 이 Task에서는 **기존 파일에 `mmt.benchmark.baseline` 영역만 추가**한다.
+
+위치: `api/src/main/resources/application-test.yml` (수정)
 
 ```yaml
-# 테스트 전용 프로파일. securelocal과 독립적이며 인클루드 관계 없음.
-# 활성화: @ActiveProfiles("test") 또는 -Dspring.profiles.active=test
-
-spring:
-  jpa:
-    properties:
-      hibernate:
-        generate_statistics: true   # Spec 01 Task 1.4의 N+1 테스트가 이 설정에 의존
-        format_sql: true
-    show-sql: false  # 로그는 logging.level로 제어
-
-logging:
-  level:
-    org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: TRACE  # Hibernate 6.x (Spring Boot 3.x)
-    # Hibernate 5.x라면: org.hibernate.type.descriptor.sql.BasicBinder: TRACE
-    org.springframework.data.neo4j.cypher: DEBUG
+# 아래 블록을 기존 application-test.yml 하단에 이어붙임
 
 mmt:
   benchmark:
@@ -83,6 +69,8 @@ mmt:
       # 예: find-results-ms: 42
       # 예: depth3-traversal-ms: 18
 ```
+
+(공통 `mmt.migration.*`, `mmt.observability.*`는 (1)에서 `application.yml`에 추가된다. test 프로파일은 그 기본값을 상속하므로 여기서 중복 선언 불필요.)
 
 ### (3) 활성화 확인
 
@@ -109,7 +97,7 @@ class FeatureFlagIntegrationTest {
 
 **산출물:**
 - [ ] `application.yml`에 `mmt.migration.*`, `mmt.observability.*` 추가
-- [ ] `application-test.yml` 신규 생성
+- [ ] `application-test.yml`에 `mmt.benchmark.baseline` 영역 추가 (뼈대는 Spec 01 Task 1.1 (3)에서 생성됨)
 - [ ] `FeatureFlagIntegrationTest` 신규 작성
 
 **검증:**


### PR DESCRIPTION
## 수정 요약
2차 /audit-doc 배치 감사에서 발견된 High 3건(구조적 결함) 해소.

## Before / After

| 문서 | Before | After |
|---|---|---|
| milestone-1 | Healthy | Healthy |
| spec-01 | Needs update (High 1) | Healthy (High 0) |
| spec-02 | Needs update (High 1) | Healthy (High 0) |
| spec-03 | Needs update (High 2) | Healthy (High 0) |

## 해소된 High 클러스터

- **Cluster A (선후 역전)**: spec-01 Task 1.1에 application-test.yml 뼈대 선행 생성, spec-03 Task 3.1은 확장 역할로 재조정
- **Cluster B (MeterRegistry 빈 부재)**: SimpleMeterRegistry 수동 Bean 등록 추가
- **Cluster C (p99 표본 부족)**: MEASURED_RUNS 100 상향, p99 통계적 유효성 확보

## 잔여 Medium/Low
모두 플래그 가중치 규칙으로 분류된 비긴급 항목. M1 실행에 장애 없음.