### PR TITLE
feat: m2 spec-02 service integration + redis caching + reactive cleanup setup

### DIFF
--- a/api/src/main/java/com/mmt/api/controller/AdminCacheController.java
+++ b/api/src/main/java/com/mmt/api/controller/AdminCacheController.java
@@ -1,0 +1,31 @@
+package com.mmt.api.controller;
+
+import com.mmt.api.service.ConceptService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * spec-02 Task 2.2: 그래프 쿼리 캐시 무효화 endpoint.
+ * SecurityConfig 의 {@code /admin/**} 매핑이 ROLE_ADMIN 을 요구하므로 별도 보안 어노테이션 불필요.
+ * CSV 재로드 후 운영자가 수동으로 호출.
+ */
+@RestController
+@RequestMapping("/admin/cache/graph")
+public class AdminCacheController {
+
+    private final ConceptService conceptService;
+
+    public AdminCacheController(ConceptService conceptService) {
+        this.conceptService = conceptService;
+    }
+
+    @PostMapping("/invalidate")
+    public ResponseEntity<Map<String, Object>> invalidateGraphCaches() {
+        long deleted = conceptService.invalidateGraphCaches();
+        return ResponseEntity.ok(Map.of("deleted", deleted));
+    }
+}

--- a/api/src/main/java/com/mmt/api/repository/concept/MysqlConceptRepository.java
+++ b/api/src/main/java/com/mmt/api/repository/concept/MysqlConceptRepository.java
@@ -1,5 +1,7 @@
 package com.mmt.api.repository.concept;
 
+import com.mmt.api.domain.Concept;
+
 import java.util.List;
 
 /**
@@ -7,12 +9,10 @@ import java.util.List;
  *
  * - M1 Spec 03 Task 3.2: 인터페이스 + 임시 Stub 도입 (분기 토글 검증용)
  * - M2 Spec 01 Task 1.1: {@link MysqlConceptRepositoryCteImpl} 이 실제 구현 제공
+ * - M2 Spec 02: 객체 반환 메서드 {@link #findPrerequisiteConcepts} 추가 (ADR 0006)
  *
  * 구현체는 {@code mmt.migration.use-mysql-cte-for-graph=true} 일 때만 bean 으로 등록되어
  * Neo4j 경로와 분기로 공존한다.
- *
- * 객체 반환 메서드 (예: {@code findPrerequisiteConcepts}) 는 Spec 02 에서
- * ADR 0006 의 {@code concepts JOIN chapters} 패턴으로 추가 예정.
  */
 public interface MysqlConceptRepository {
 
@@ -25,4 +25,15 @@ public interface MysqlConceptRepository {
      * @return concept_id 목록 (시작 노드 포함, 중복 제거됨)
      */
     List<Integer> findPrerequisiteConceptIds(int conceptId, int maxDepth);
+
+    /**
+     * 시작 노드의 직접 + 재귀 선수 개념을 {@link Concept} 객체 형태로 반환.
+     * ADR 0006 의 {@code concepts JOIN chapters} 패턴으로 12 개 필드를 매핑하며,
+     * {@code conceptSection} 은 매핑 생략 (프론트 미사용 + 단일 조회 경로와 일관).
+     *
+     * @param conceptId 시작 노드의 concept_id
+     * @param maxDepth  최대 깊이 (0 → 자기 자신만, N → N 단계 이내 모든 선수)
+     * @return Concept 목록 (시작 노드 포함, 중복 제거됨)
+     */
+    List<Concept> findPrerequisiteConcepts(int conceptId, int maxDepth);
 }

--- a/api/src/main/java/com/mmt/api/repository/concept/MysqlConceptRepositoryCteImpl.java
+++ b/api/src/main/java/com/mmt/api/repository/concept/MysqlConceptRepositoryCteImpl.java
@@ -1,7 +1,9 @@
 package com.mmt.api.repository.concept;
 
+import com.mmt.api.domain.Concept;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -44,6 +46,32 @@ public class MysqlConceptRepositoryCteImpl implements MysqlConceptRepository {
         SELECT DISTINCT concept_id FROM prerequisite_path
         """;
 
+    /**
+     * ADR 0006: concepts JOIN chapters 12 필드 매핑. conceptSection 은 매핑 생략.
+     * 다중 경로 중복 제거를 위해 외부 SELECT 의 FROM 절에서 (SELECT DISTINCT concept_id ...) subquery 로 평탄화.
+     */
+    private static final String SQL_FIND_PREREQUISITE_CONCEPTS = """
+        WITH RECURSIVE prerequisite_path AS (
+            SELECT concept_id, 0 AS depth
+            FROM concepts WHERE concept_id = ?
+
+            UNION ALL
+
+            SELECT c.concept_id, pp.depth + 1
+            FROM prerequisite_path pp
+            JOIN knowledge_space ks ON pp.concept_id = ks.to_concept_id
+            JOIN concepts         c ON ks.from_concept_id = c.concept_id
+            WHERE pp.depth < ?
+        )
+        SELECT c.concept_id, c.concept_name, c.concept_description,
+               c.concept_chapter_id, c.concept_achievement_id, c.concept_achievement_name,
+               ch.school_level, ch.grade_level, ch.semester,
+               ch.chapter_main, ch.chapter_sub, ch.chapter_name
+        FROM (SELECT DISTINCT concept_id FROM prerequisite_path) pp
+        JOIN concepts c  ON pp.concept_id = c.concept_id
+        JOIN chapters ch ON c.concept_chapter_id = ch.chapter_id
+        """;
+
     private final JdbcTemplate jdbcTemplate;
 
     public MysqlConceptRepositoryCteImpl(JdbcTemplate jdbcTemplate) {
@@ -52,11 +80,41 @@ public class MysqlConceptRepositoryCteImpl implements MysqlConceptRepository {
 
     @Override
     public List<Integer> findPrerequisiteConceptIds(int conceptId, int maxDepth) {
+        validateMaxDepth(maxDepth);
+        return jdbcTemplate.queryForList(
+            SQL_FIND_PREREQUISITE_IDS, Integer.class, conceptId, maxDepth);
+    }
+
+    @Override
+    public List<Concept> findPrerequisiteConcepts(int conceptId, int maxDepth) {
+        validateMaxDepth(maxDepth);
+        return jdbcTemplate.query(
+            SQL_FIND_PREREQUISITE_CONCEPTS, conceptRowMapper(), conceptId, maxDepth);
+    }
+
+    private static void validateMaxDepth(int maxDepth) {
         if (maxDepth < 0) {
             throw new IllegalArgumentException(
                 "maxDepth must be >= 0 (got " + maxDepth + ")");
         }
-        return jdbcTemplate.queryForList(
-            SQL_FIND_PREREQUISITE_IDS, Integer.class, conceptId, maxDepth);
+    }
+
+    private RowMapper<Concept> conceptRowMapper() {
+        return (rs, rowNum) -> {
+            Concept c = new Concept();
+            c.setConceptId(rs.getInt("concept_id"));
+            c.setName(rs.getString("concept_name"));
+            c.setDesc(rs.getString("concept_description"));
+            c.setChapterId(rs.getInt("concept_chapter_id"));
+            c.setAchievementId(rs.getInt("concept_achievement_id"));
+            c.setAchievementName(rs.getString("concept_achievement_name"));
+            c.setSchoolLevel(rs.getString("school_level"));
+            c.setGradeLevel(rs.getString("grade_level"));
+            c.setSemester(rs.getString("semester"));
+            c.setChapterMain(rs.getString("chapter_main"));
+            c.setChapterSub(rs.getString("chapter_sub"));
+            c.setChapterName(rs.getString("chapter_name"));
+            return c;
+        };
     }
 }

--- a/api/src/main/java/com/mmt/api/service/ConceptService.java
+++ b/api/src/main/java/com/mmt/api/service/ConceptService.java
@@ -1,7 +1,9 @@
 package com.mmt.api.service;
 
 
-import com.mmt.api.dto.concept.ChapterIdConceptResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mmt.api.domain.Concept;
 import com.mmt.api.dto.concept.ConceptConverter;
 import com.mmt.api.dto.concept.ConceptNameResponse;
 import com.mmt.api.dto.concept.ConceptResponse;
@@ -9,17 +11,29 @@ import com.mmt.api.repository.concept.ConceptRepository;
 import com.mmt.api.repository.concept.JdbcTemplateConceptRepository;
 import com.mmt.api.repository.concept.MysqlConceptRepository;
 import com.mmt.api.repository.knowledgeSpace.KnowledgeSpaceRepository;
+import com.mmt.api.util.RedisUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 @Service
 public class ConceptService {
+
+    // ADR 0004: RedisUtil 직접 호출 캐싱.
+    // RedisUtil.set 의 duration 단위는 MILLISECONDS (RedisUtil:19).
+    private static final long TTL_24H = Duration.ofHours(24).toMillis();
+
+    // 캐시 키 prefix (ADR 0004 + spec-02 Task 2.1 규약)
+    private static final String KEY_IDS_PREFIX = "graph:prerequisites:ids:";
+    private static final String KEY_OBJS_PREFIX = "graph:prerequisites:objs:";
+    private static final String KEY_TO_CONCEPTS_PREFIX = "graph:to-concepts:";
 
     private final ConceptRepository conceptRepository;
     private final KnowledgeSpaceRepository knowledgeSpaceRepository;
@@ -27,6 +41,8 @@ public class ConceptService {
     // M1 Spec 03 Task 3.2: 피처 플래그 true 일 때만 스텁 bean 이 등록됨.
     // Optional 주입으로 false 상태에서 bean 미존재여도 컨텍스트 기동 가능.
     private final Optional<MysqlConceptRepository> mysqlConceptRepository;
+    private final RedisUtil redisUtil;
+    private final ObjectMapper objectMapper;
 
     @Value("${mmt.migration.use-mysql-cte-for-graph:false}")
     private boolean useMysqlCte;
@@ -35,12 +51,16 @@ public class ConceptService {
         ConceptRepository conceptRepository,
         KnowledgeSpaceRepository knowledgeSpaceRepository,
         JdbcTemplateConceptRepository jdbcTemplateConceptRepository,
-        Optional<MysqlConceptRepository> mysqlConceptRepository
+        Optional<MysqlConceptRepository> mysqlConceptRepository,
+        RedisUtil redisUtil,
+        ObjectMapper objectMapper
     ) {
         this.conceptRepository = conceptRepository;
         this.knowledgeSpaceRepository = knowledgeSpaceRepository;
         this.jdbcTemplateConceptRepository = jdbcTemplateConceptRepository;
         this.mysqlConceptRepository = mysqlConceptRepository;
+        this.redisUtil = redisUtil;
+        this.objectMapper = objectMapper;
     }
 
     @Transactional(readOnly = true)
@@ -50,6 +70,16 @@ public class ConceptService {
 
     @Transactional(readOnly = true)
     public Flux<ConceptResponse> findToConcepts(int conceptId){
+        if (useMysqlCte && mysqlConceptRepository.isPresent()) {
+            // ADR 0003: backward 단일 방향 → depth=1 의 선수가 곧 to-concepts.
+            // Cypher (n)-[r]->(m{conceptId}) 는 m 미포함이므로 시작 노드 필터링 필수.
+            String key = KEY_TO_CONCEPTS_PREFIX + conceptId;
+            List<Concept> concepts = cachedConceptsOrCompute(key, () ->
+                mysqlConceptRepository.get().findPrerequisiteConcepts(conceptId, 1).stream()
+                    .filter(c -> c.getConceptId() != conceptId)
+                    .collect(Collectors.toList()));
+            return ConceptConverter.convertToFluxConceptResponse(Flux.fromIterable(concepts));
+        }
         return ConceptConverter.convertToFluxConceptResponse(conceptRepository.findToConceptsByConceptId(conceptId));
     }
 
@@ -58,28 +88,43 @@ public class ConceptService {
         // 해당 컨셉 아이디가 속한 학교급 찾기
         String schoolLevel = jdbcTemplateConceptRepository.findSchoolLevelByConceptId(conceptId);
         // 학교급에 따라 다른 메서드 사용
-        if (schoolLevel.equals("초등")) return ConceptConverter.convertToFluxConceptResponse(conceptRepository.findNodesByConceptIdDepth3(conceptId));
-        else return ConceptConverter.convertToFluxConceptResponse(conceptRepository.findNodesByConceptIdDepth5(conceptId));
+        int depth = schoolLevel.equals("초등") ? 3 : 5;
+
+        if (useMysqlCte && mysqlConceptRepository.isPresent()) {
+            String key = KEY_OBJS_PREFIX + conceptId + ":" + depth;
+            List<Concept> concepts = cachedConceptsOrCompute(key, () ->
+                mysqlConceptRepository.get().findPrerequisiteConcepts(conceptId, depth));
+            return ConceptConverter.convertToFluxConceptResponse(Flux.fromIterable(concepts));
+        }
+
+        Flux<Concept> source = depth == 3
+            ? conceptRepository.findNodesByConceptIdDepth3(conceptId)
+            : conceptRepository.findNodesByConceptIdDepth5(conceptId);
+        return ConceptConverter.convertToFluxConceptResponse(source);
     }
 
     @Transactional(readOnly = true)
     public Flux<Integer> findNodesIdByConceptIdDepth2(int conceptId){
+        if (useMysqlCte && mysqlConceptRepository.isPresent()) {
+            return Flux.fromIterable(cachedIdsOrCompute(conceptId, 2));
+        }
         return conceptRepository.findNodesIdByConceptIdDepth2(conceptId);
     }
-    // M1 Spec 03 Task 3.2: M2 MySQL CTE 마이그레이션을 위한 조건 분기.
+    // M1 Spec 03 Task 3.2 / M2 Spec 02 Task 3.1: M2 MySQL CTE 마이그레이션을 위한 조건 분기.
     // 반환 타입 Flux<Integer> 는 그대로 유지 (ProbabilityService:65 등 기존 호출자와 호환).
     // true 경로는 리스트를 Flux.fromIterable 로 래핑해 동일 시그니처 보존.
-    // 나머지 depth2/5 메서드는 M2 에서 동일 패턴으로 확장 예정.
     @Transactional(readOnly = true)
     public Flux<Integer> findNodesIdByConceptIdDepth3(int conceptId){
         if (useMysqlCte && mysqlConceptRepository.isPresent()) {
-            return Flux.fromIterable(
-                mysqlConceptRepository.get().findPrerequisiteConceptIds(conceptId, 3));
+            return Flux.fromIterable(cachedIdsOrCompute(conceptId, 3));
         }
         return conceptRepository.findNodesIdByConceptIdDepth3(conceptId);
     }
     @Transactional(readOnly = true)
     public Flux<Integer> findNodesIdByConceptIdDepth5(int conceptId){
+        if (useMysqlCte && mysqlConceptRepository.isPresent()) {
+            return Flux.fromIterable(cachedIdsOrCompute(conceptId, 5));
+        }
         return conceptRepository.findNodesIdByConceptIdDepth5(conceptId);
     }
 
@@ -109,5 +154,60 @@ public class ConceptService {
 //        // Flux<NodeResponse> 자체를 리스펀스 보내는 건 성공했지만 Flux<NodeResponse>를 통채로 NetworkResponse의 필드로 담는 건 실패
 //        return networkResponse;
 //    }
+
+    // ─── 캐싱 헬퍼 (ADR 0004) ───
+
+    /**
+     * List<Integer> 캐시 헬퍼. RedisUtil 의 Jackson2JsonRedisSerializer(ArrayList.class)
+     * 라운드트립이 Integer 에는 안전 (스칼라 타입은 default typing 없이도 복원됨).
+     */
+    private List<Integer> cachedIdsOrCompute(int conceptId, int depth) {
+        String key = KEY_IDS_PREFIX + conceptId + ":" + depth;
+        Object raw = redisUtil.get(key);
+        if (raw instanceof List<?> list) {
+            // ArrayList<Integer> 또는 ArrayList<Number> (Jackson 정수 디시리얼라이즈) 를 정규화
+            return list.stream()
+                .map(o -> ((Number) o).intValue())
+                .collect(Collectors.toList());
+        }
+        List<Integer> result = mysqlConceptRepository.get()
+            .findPrerequisiteConceptIds(conceptId, depth);
+        redisUtil.set(key, result, TTL_24H);
+        return result;
+    }
+
+    /**
+     * List<Concept> 캐시 헬퍼. RedisUtil 의 기본 직렬화는 default typing 미적용으로 POJO 라운드트립 불가.
+     * 따라서 ObjectMapper 로 JSON 문자열 변환 후 String 으로 저장하고, 읽을 때 TypeReference 로 복원한다.
+     * 직렬화 실패 시 캐시 미스로 처리하여 저장만 스킵 (호출자 영향 없음).
+     */
+    private List<Concept> cachedConceptsOrCompute(String key, Supplier<List<Concept>> compute) {
+        Object raw = redisUtil.get(key);
+        if (raw instanceof String json) {
+            try {
+                return objectMapper.readValue(json, new TypeReference<List<Concept>>() {});
+            } catch (Exception ignored) {
+                // 캐시 형식 변경 등으로 파싱 실패 시 미스로 처리
+            }
+        }
+        List<Concept> result = compute.get();
+        try {
+            redisUtil.set(key, objectMapper.writeValueAsString(result), TTL_24H);
+        } catch (Exception ignored) {
+            // 직렬화 실패 시 캐시 저장만 건너뛰고 결과는 정상 반환
+        }
+        return result;
+    }
+
+    /**
+     * spec-02 Task 2.2: 그래프 캐시 prefix 3종 일괄 삭제. AdminController 가 호출.
+     * @return 삭제된 키 총 개수
+     */
+    public long invalidateGraphCaches() {
+        long ids = redisUtil.deleteByPattern(KEY_IDS_PREFIX + "*");
+        long objs = redisUtil.deleteByPattern(KEY_OBJS_PREFIX + "*");
+        long toConcepts = redisUtil.deleteByPattern(KEY_TO_CONCEPTS_PREFIX + "*");
+        return ids + objs + toConcepts;
+    }
 
 }

--- a/api/src/main/java/com/mmt/api/service/KnowledgeSpaceService.java
+++ b/api/src/main/java/com/mmt/api/service/KnowledgeSpaceService.java
@@ -1,9 +1,7 @@
 package com.mmt.api.service;
 
-import com.mmt.api.dto.concept.ConceptConverter;
 import com.mmt.api.dto.network.EdgeResponse;
 import com.mmt.api.dto.network.NetworkConverter;
-import com.mmt.api.repository.concept.ConceptRepository;
 import com.mmt.api.repository.concept.JdbcTemplateConceptRepository;
 import com.mmt.api.repository.knowledgeSpace.KnowledgeSpaceRepository;
 import org.springframework.stereotype.Service;
@@ -16,25 +14,32 @@ import java.util.List;
 public class KnowledgeSpaceService {
 
     private final KnowledgeSpaceRepository knowledgeSpaceRepository;
-    private final ConceptRepository conceptRepository;
     private final JdbcTemplateConceptRepository jdbcTemplateConceptRepository;
-    public KnowledgeSpaceService(KnowledgeSpaceRepository knowledgeSpaceRepository, ConceptRepository conceptRepository, JdbcTemplateConceptRepository jdbcTemplateConceptRepository) {
+    // M2 Spec 02 Task 3.1 옵션 B: ConceptService 의 그래프 메서드를 경유하여
+    // 피처 플래그 분기·캐싱이 자동 상속되도록 한다. ConceptRepository 직접 호출 제거.
+    private final ConceptService conceptService;
+
+    public KnowledgeSpaceService(KnowledgeSpaceRepository knowledgeSpaceRepository,
+                                 JdbcTemplateConceptRepository jdbcTemplateConceptRepository,
+                                 ConceptService conceptService) {
         this.knowledgeSpaceRepository = knowledgeSpaceRepository;
-        this.conceptRepository = conceptRepository;
         this.jdbcTemplateConceptRepository = jdbcTemplateConceptRepository;
+        this.conceptService = conceptService;
     }
 
     public List<EdgeResponse> findEdgesByConceptId(int conceptId){
         // 해당 컨셉 아이디가 속한 학교급 찾기
         String schoolLevel = jdbcTemplateConceptRepository.findSchoolLevelByConceptId(conceptId);
 
-        // 학교급에 따라 다른 메서드 사용
-        Flux<Integer> conceptIdFlux;
-        if (schoolLevel.equals("초등")) conceptIdFlux = conceptRepository.findNodesIdByConceptIdDepth3(conceptId);
-        else conceptIdFlux = conceptRepository.findNodesIdByConceptIdDepth5(conceptId);
+        // 학교급에 따라 다른 메서드 사용 (ConceptService 경유 → 분기·캐싱 자동 상속)
+        Flux<Integer> conceptIdFlux = schoolLevel.equals("초등")
+            ? conceptService.findNodesIdByConceptIdDepth3(conceptId)
+            : conceptService.findNodesIdByConceptIdDepth5(conceptId);
 
+        // CTE 경로는 동기 결과를 Flux 로 래핑한 형태이므로 .block() 이 즉시 반환.
+        // Neo4j 경로는 reactive — spec-03 Task 5.3 Neo4j 폐기 시 .block() 자체 삭제 예정.
         List<Integer> conceptIdList = conceptIdFlux.distinct().collectList().block();
-        if (conceptIdList.isEmpty()){ // 선수단위개념이 없는 최초의 단위개념
+        if (conceptIdList == null || conceptIdList.isEmpty()){ // 선수단위개념이 없는 최초의 단위개념
             return new ArrayList<>();
         } else {
             return NetworkConverter.convertToEdgeResponseList(knowledgeSpaceRepository.findEdgesByConceptId(conceptIdList));

--- a/api/src/main/java/com/mmt/api/util/RedisUtil.java
+++ b/api/src/main/java/com/mmt/api/util/RedisUtil.java
@@ -1,10 +1,14 @@
 package com.mmt.api.util;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.stereotype.Component;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -46,6 +50,29 @@ public class RedisUtil {
 
     public boolean hasKeyBlackList(String key) {
         return redisBlackListTemplate.hasKey(key);
+    }
+
+    /**
+     * SCAN 으로 prefix 일치 키를 수집한 뒤 일괄 삭제. KEYS 는 O(N) 블로킹이라 비권장 → SCAN.
+     * spec-02 Task 2.2 (그래프 캐시 무효화) 용도. 호출 빈도가 낮은 관리자 endpoint 에서만 사용.
+     *
+     * @param pattern Redis 패턴 (예: "graph:prerequisites:ids:*")
+     * @return 삭제된 키 개수
+     */
+    public long deleteByPattern(String pattern) {
+        Set<String> keys = new HashSet<>();
+        ScanOptions options = ScanOptions.scanOptions().match(pattern).count(100).build();
+        try (Cursor<byte[]> cursor = redisTemplate.executeWithStickyConnection(
+                conn -> conn.scan(options))) {
+            while (cursor.hasNext()) {
+                keys.add(new String(cursor.next()));
+            }
+        }
+        if (keys.isEmpty()) {
+            return 0L;
+        }
+        Long deleted = redisTemplate.delete(keys);
+        return deleted == null ? 0L : deleted;
     }
 
 }

--- a/api/src/test/java/com/mmt/api/ApiApplicationTests.java
+++ b/api/src/test/java/com/mmt/api/ApiApplicationTests.java
@@ -1,9 +1,16 @@
 package com.mmt.api;
 
+import com.mmt.api.config.TestcontainersConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest
+@Import(TestcontainersConfig.class)
+@ActiveProfiles("test")
+@Testcontainers
 class ApiApplicationTests {
 
 	@Test

--- a/api/src/test/java/com/mmt/api/config/TestcontainersConfig.java
+++ b/api/src/test/java/com/mmt/api/config/TestcontainersConfig.java
@@ -3,8 +3,10 @@ package com.mmt.api.config;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 // TODO(readme): 로컬에서 .withReuse(true) 효과를 보려면 개발자가
@@ -37,5 +39,20 @@ public class TestcontainersConfig {
                 MountableFile.forHostPath("../neo4j/init/knowledge_space.csv"),
                 "/var/lib/neo4j/import/knowledge_space.csv")
             .withReuse(true);
+    }
+
+    // M2 Spec 02: 그래프 캐시 (RedisUtil 직접 호출) 통합 테스트 용도.
+    // ConceptServiceCteIntegrationTest 가 분기 + 캐싱 경로를 동시에 검증.
+    // application.yml 의 spring.redis.host/port 를 노출된 컨테이너 주소로 오버라이드.
+    @Bean
+    public GenericContainer<?> redisContainer() {
+        GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379)
+            .withReuse(true);
+        redis.start();
+        System.setProperty("spring.redis.host", redis.getHost());
+        System.setProperty("spring.redis.port", String.valueOf(redis.getMappedPort(6379)));
+        System.setProperty("spring.redis.password", "");
+        return redis;
     }
 }

--- a/api/src/test/java/com/mmt/api/repository/concept/MysqlConceptRepositoryCteTest.java
+++ b/api/src/test/java/com/mmt/api/repository/concept/MysqlConceptRepositoryCteTest.java
@@ -1,6 +1,7 @@
 package com.mmt.api.repository.concept;
 
 import com.mmt.api.config.TestcontainersConfig;
+import com.mmt.api.domain.Concept;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,6 +96,66 @@ class MysqlConceptRepositoryCteTest {
     @Test
     void negativeMaxDepthThrowsIllegalArgumentException() {
         assertThatThrownBy(() -> repository.findPrerequisiteConceptIds(10, -1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("maxDepth");
+    }
+
+    // ─── findPrerequisiteConcepts (객체 반환, ADR 0006: concepts JOIN chapters) ───
+
+    @Test
+    void findPrerequisiteConceptsDepth0ReturnsOnlyStartNodeWithChapterFields() {
+        List<Concept> result = repository.findPrerequisiteConcepts(10, 0);
+
+        assertThat(result).hasSize(1);
+        Concept c = result.get(0);
+        assertThat(c.getConceptId()).isEqualTo(10);
+        assertThat(c.getName()).isEqualTo("start node");
+        assertThat(c.getDesc()).isEqualTo("desc 10");
+        assertThat(c.getChapterId()).isEqualTo(1);
+        assertThat(c.getAchievementId()).isEqualTo(1);
+        assertThat(c.getAchievementName()).isEqualTo("achievement 1");
+        assertThat(c.getSchoolLevel()).isEqualTo("초등");
+        assertThat(c.getGradeLevel()).isEqualTo("초1");
+        assertThat(c.getSemester()).isEqualTo("1학기");
+        assertThat(c.getChapterName()).isEqualTo("cte-test-chapter");
+        assertThat(c.getChapterMain()).isEqualTo("");
+        assertThat(c.getChapterSub()).isEqualTo("9까지의 수");
+        // ADR 0006: section 매핑 생략 → null
+        assertThat(c.getSection()).isNull();
+    }
+
+    @Test
+    void findPrerequisiteConceptsDepth5ReturnsAllReachable() {
+        List<Concept> result = repository.findPrerequisiteConcepts(10, 5);
+        assertThat(result).extracting(Concept::getConceptId)
+            .containsExactlyInAnyOrder(10, 1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    void findPrerequisiteConceptsDeduplicatesMultiplePaths() {
+        // depth 2 의 노드 3 은 두 경로로 도달 — 외부 SELECT 의 DISTINCT subquery 가 1 row 로 평탄화
+        List<Concept> result = repository.findPrerequisiteConcepts(10, 2);
+        assertThat(result).extracting(Concept::getConceptId)
+            .containsExactlyInAnyOrder(10, 1, 2, 3);
+        assertThat(result).hasSize(4);
+    }
+
+    @Test
+    void findPrerequisiteConceptsIsolatedNodeReturnsOnlySelf() {
+        List<Concept> result = repository.findPrerequisiteConcepts(7, 5);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getConceptId()).isEqualTo(7);
+    }
+
+    @Test
+    void findPrerequisiteConceptsNonExistentReturnsEmpty() {
+        List<Concept> result = repository.findPrerequisiteConcepts(999, 5);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findPrerequisiteConceptsNegativeMaxDepthThrows() {
+        assertThatThrownBy(() -> repository.findPrerequisiteConcepts(10, -1))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("maxDepth");
     }

--- a/api/src/test/java/com/mmt/api/service/ConceptServiceCacheTest.java
+++ b/api/src/test/java/com/mmt/api/service/ConceptServiceCacheTest.java
@@ -1,0 +1,191 @@
+package com.mmt.api.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mmt.api.domain.Concept;
+import com.mmt.api.repository.concept.ConceptRepository;
+import com.mmt.api.repository.concept.JdbcTemplateConceptRepository;
+import com.mmt.api.repository.concept.MysqlConceptRepository;
+import com.mmt.api.repository.knowledgeSpace.KnowledgeSpaceRepository;
+import com.mmt.api.util.RedisUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * spec-02 Task 2.1 캐시 동작 단위 테스트.
+ *
+ * 검증 범위:
+ *  - cache miss → 리포지토리 호출 + Redis set
+ *  - cache hit  → 리포지토리 미호출
+ *  - invalidate → deleteByPattern 3 개 prefix 호출
+ *
+ * SpringBootTest 미사용. Mockito 로 RedisUtil + MysqlConceptRepository 격리하여
+ * 캐싱 헬퍼 (cachedIdsOrCompute, cachedConceptsOrCompute) 의 동작만 검증.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConceptServiceCacheTest {
+
+    @Mock private ConceptRepository conceptRepository;
+    @Mock private KnowledgeSpaceRepository knowledgeSpaceRepository;
+    @Mock private JdbcTemplateConceptRepository jdbcTemplateConceptRepository;
+    @Mock private MysqlConceptRepository mysqlConceptRepository;
+    @Mock private RedisUtil redisUtil;
+
+    private ConceptService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ConceptService(
+            conceptRepository,
+            knowledgeSpaceRepository,
+            jdbcTemplateConceptRepository,
+            Optional.of(mysqlConceptRepository),
+            redisUtil,
+            new ObjectMapper()
+        );
+        // 피처 플래그 true 강제 (테스트는 CTE 경로만 다룸)
+        ReflectionTestUtils.setField(service, "useMysqlCte", true);
+    }
+
+    // ─── cachedIdsOrCompute (List<Integer>) ───
+
+    @Test
+    void idsCacheMissCallsRepositoryAndStores() {
+        when(redisUtil.get("graph:prerequisites:ids:10:3")).thenReturn(null);
+        when(mysqlConceptRepository.findPrerequisiteConceptIds(10, 3))
+            .thenReturn(List.of(10, 1, 2, 3, 4));
+
+        List<Integer> result = service.findNodesIdByConceptIdDepth3(10)
+            .collectList().block();
+
+        assertThat(result).containsExactly(10, 1, 2, 3, 4);
+        verify(mysqlConceptRepository, times(1)).findPrerequisiteConceptIds(10, 3);
+        verify(redisUtil, times(1)).set(
+            eq("graph:prerequisites:ids:10:3"), any(List.class), anyLong());
+    }
+
+    @Test
+    void idsCacheHitSkipsRepository() {
+        when(redisUtil.get("graph:prerequisites:ids:10:3"))
+            .thenReturn(List.of(10, 1, 2, 3, 4));
+
+        List<Integer> result = service.findNodesIdByConceptIdDepth3(10)
+            .collectList().block();
+
+        assertThat(result).containsExactly(10, 1, 2, 3, 4);
+        verify(mysqlConceptRepository, never()).findPrerequisiteConceptIds(anyInt(), anyInt());
+        verify(redisUtil, never()).set(any(), any(), anyLong());
+    }
+
+    @Test
+    void idsCacheNormalizesNumberType() {
+        // Jackson 의 정수 디시리얼라이즈가 Long 으로 떨어질 수 있음 — Number 캐스팅 후 intValue() 정규화
+        when(redisUtil.get("graph:prerequisites:ids:10:5"))
+            .thenReturn(List.of(10L, 1L, 2L));
+
+        List<Integer> result = service.findNodesIdByConceptIdDepth5(10)
+            .collectList().block();
+
+        assertThat(result).containsExactly(10, 1, 2);
+        verify(mysqlConceptRepository, never()).findPrerequisiteConceptIds(anyInt(), anyInt());
+    }
+
+    // ─── cachedConceptsOrCompute (List<Concept>) ───
+
+    @Test
+    void conceptsCacheMissCallsRepositoryAndStores() {
+        when(jdbcTemplateConceptRepository.findSchoolLevelByConceptId(10)).thenReturn("초등");
+        when(redisUtil.get("graph:prerequisites:objs:10:3")).thenReturn(null);
+
+        Concept c = new Concept();
+        c.setConceptId(10);
+        c.setName("start");
+        when(mysqlConceptRepository.findPrerequisiteConcepts(10, 3))
+            .thenReturn(List.of(c));
+
+        var result = service.findNodesByConceptId(10).collectList().block();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getConceptId()).isEqualTo(10);
+        verify(mysqlConceptRepository, times(1)).findPrerequisiteConcepts(10, 3);
+        verify(redisUtil, times(1)).set(
+            eq("graph:prerequisites:objs:10:3"),
+            any(String.class),  // ObjectMapper 로 JSON 직렬화한 String 저장
+            anyLong());
+    }
+
+    @Test
+    void conceptsCacheHitDeserializesFromJsonString() throws Exception {
+        when(jdbcTemplateConceptRepository.findSchoolLevelByConceptId(10)).thenReturn("고등");
+
+        Concept c = new Concept();
+        c.setConceptId(10);
+        c.setName("cached node");
+        c.setSchoolLevel("고등");
+        String json = new ObjectMapper().writeValueAsString(List.of(c));
+        when(redisUtil.get("graph:prerequisites:objs:10:5")).thenReturn(json);
+
+        var result = service.findNodesByConceptId(10).collectList().block();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getConceptId()).isEqualTo(10);
+        assertThat(result.get(0).getConceptName()).isEqualTo("cached node");
+        assertThat(result.get(0).getConceptSchoolLevel()).isEqualTo("고등");
+        verify(mysqlConceptRepository, never()).findPrerequisiteConcepts(anyInt(), anyInt());
+    }
+
+    // ─── findToConcepts: depth=1 + self 필터링 ───
+
+    @Test
+    void findToConceptsFiltersOutStartNode() {
+        when(redisUtil.get("graph:to-concepts:10")).thenReturn(null);
+
+        Concept self = new Concept();
+        self.setConceptId(10);
+        Concept prereq1 = new Concept();
+        prereq1.setConceptId(1);
+        Concept prereq2 = new Concept();
+        prereq2.setConceptId(2);
+
+        // CTE depth=1 은 자기 자신 + 직접 선수 반환 → 자기 자신 제외 후 to-concepts 와 동치
+        when(mysqlConceptRepository.findPrerequisiteConcepts(10, 1))
+            .thenReturn(List.of(self, prereq1, prereq2));
+
+        var result = service.findToConcepts(10).collectList().block();
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("conceptId").containsExactlyInAnyOrder(1, 2);
+    }
+
+    // ─── invalidateGraphCaches ───
+
+    @Test
+    void invalidateGraphCachesDeletesAllThreePrefixes() {
+        when(redisUtil.deleteByPattern("graph:prerequisites:ids:*")).thenReturn(3L);
+        when(redisUtil.deleteByPattern("graph:prerequisites:objs:*")).thenReturn(2L);
+        when(redisUtil.deleteByPattern("graph:to-concepts:*")).thenReturn(1L);
+
+        long deleted = service.invalidateGraphCaches();
+
+        assertThat(deleted).isEqualTo(6L);
+        verify(redisUtil).deleteByPattern("graph:prerequisites:ids:*");
+        verify(redisUtil).deleteByPattern("graph:prerequisites:objs:*");
+        verify(redisUtil).deleteByPattern("graph:to-concepts:*");
+    }
+}

--- a/api/src/test/java/com/mmt/api/service/ConceptServiceCteIntegrationTest.java
+++ b/api/src/test/java/com/mmt/api/service/ConceptServiceCteIntegrationTest.java
@@ -1,0 +1,82 @@
+package com.mmt.api.service;
+
+import com.mmt.api.config.TestcontainersConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * spec-02 Task 3.1 분기 동등성 (CTE 경로 = mmt.migration.use-mysql-cte-for-graph=true).
+ *
+ * 목적: MysqlConceptRepositoryCteImpl 이 실제 SpringBootTest 컨텍스트에서 등록되고
+ * ConceptService 의 CTE 분기 + 캐싱 헬퍼가 정상 라우팅되는지 검증.
+ *
+ * 시드 SQL (cte_test_*.sql) 은 spec-01 의 단위 테스트와 동일 — 동일 그래프
+ * (6→5→4→3→{1,2}→10) 위에서 ConceptService 와 MysqlConceptRepositoryCteImpl 의
+ * 결과가 일치함을 확인 (서비스 계층 wrapping 회귀 보호).
+ *
+ * Neo4j fallback 경로는 ConceptServiceFeatureFlagTest 에서 다룬다 (false 분기).
+ */
+@SpringBootTest
+@Import(TestcontainersConfig.class)
+@ActiveProfiles("test")
+@TestPropertySource(properties = "mmt.migration.use-mysql-cte-for-graph=true")
+@Testcontainers
+@Sql(scripts = {"/sql/cte_test_schema.sql", "/sql/cte_test_seed.sql"})
+class ConceptServiceCteIntegrationTest {
+
+    @Autowired
+    private ConceptService service;
+
+    @Test
+    void cteBranchReturnsExpectedDepth3Ids() {
+        List<Integer> result = service.findNodesIdByConceptIdDepth3(10)
+            .collectList().block();
+        assertThat(result).containsExactlyInAnyOrder(10, 1, 2, 3, 4);
+    }
+
+    @Test
+    void cteBranchReturnsExpectedDepth5Ids() {
+        List<Integer> result = service.findNodesIdByConceptIdDepth5(10)
+            .collectList().block();
+        assertThat(result).containsExactlyInAnyOrder(10, 1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    void cteBranchReturnsExpectedDepth2Ids() {
+        // 다중 경로 (3 → 1, 3 → 2) 가 외부 SELECT DISTINCT 로 평탄화되어 4 개만 반환
+        List<Integer> result = service.findNodesIdByConceptIdDepth2(10)
+            .collectList().block();
+        assertThat(result).containsExactlyInAnyOrder(10, 1, 2, 3);
+    }
+
+    @Test
+    void cteBranchFindToConceptsExcludesStartNode() {
+        // ADR 0006: findPrerequisiteConcepts(?, 1) - {start} → Cypher (n)-[r]->(m{?}) 와 동치
+        var result = service.findToConcepts(10).collectList().block();
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("conceptId").containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
+    void cteBranchFindNodesByConceptIdReturnsAllPrerequisitesIncludingSelf() {
+        // depth 결정: 학교급 = "초등" (시드의 chapter.school_level) → depth 3
+        var result = service.findNodesByConceptId(10).collectList().block();
+        assertThat(result).extracting("conceptId").containsExactlyInAnyOrder(10, 1, 2, 3, 4);
+        // chapters JOIN 동작 확인 — 한 객체 검사
+        assertThat(result).anySatisfy(r -> {
+            assertThat(r.getConceptSchoolLevel()).isEqualTo("초등");
+            assertThat(r.getConceptGradeLevel()).isEqualTo("초1");
+            assertThat(r.getConceptChapterName()).isEqualTo("cte-test-chapter");
+        });
+    }
+}

--- a/api/src/test/java/com/mmt/api/util/RedisUtilTest.java
+++ b/api/src/test/java/com/mmt/api/util/RedisUtilTest.java
@@ -1,5 +1,6 @@
 package com.mmt.api.util;
 
+import com.mmt.api.config.TestcontainersConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -7,12 +8,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
 @SpringBootTest
+@Import(TestcontainersConfig.class)
+@ActiveProfiles("test")
+@Testcontainers
 class RedisUtilTest {
     final String KEY = "key";
     final String VALUE = "value";

--- a/api/src/test/resources/sql/cte_test_schema.sql
+++ b/api/src/test/resources/sql/cte_test_schema.sql
@@ -1,15 +1,34 @@
--- M2 Spec 01 Task 1.5: CTE 단위 테스트 전용 schema (옵션 A)
+-- M2 Spec 01 Task 1.5 / Spec 02 Task 1.1: CTE 단위 테스트 전용 schema (옵션 A)
 --
--- production create.sql 의 일부 (concepts + knowledge_space) 를 단위 테스트용으로 축소.
+-- production create.sql 의 일부 (concepts + chapters + knowledge_space) 를 단위 테스트용으로 축소.
 -- @Sql 이 매 테스트 전 실행되므로 DROP IF EXISTS 로 idempotent 유지.
 -- 인덱스는 production 과 동일하게 박아 EXPLAIN 동작 일관성 검증 가능.
+--
+-- chapters 테이블은 spec-02 의 findPrerequisiteConcepts (concepts JOIN chapters, ADR 0006) 검증용.
+-- spec-01 의 findPrerequisiteConceptIds 는 chapters 미사용 → JOIN 영향 없음.
 
 DROP TABLE IF EXISTS knowledge_space;
 DROP TABLE IF EXISTS concepts;
+DROP TABLE IF EXISTS chapters;
+
+CREATE TABLE chapters (
+    chapter_id INT,
+    chapter_name VARCHAR(50),
+    school_level VARCHAR(5),
+    grade_level VARCHAR(5),
+    semester VARCHAR(5),
+    chapter_main VARCHAR(50),
+    chapter_sub VARCHAR(50),
+    PRIMARY KEY (chapter_id)
+);
 
 CREATE TABLE concepts (
     concept_id INT,
     concept_name VARCHAR(70),
+    concept_description TEXT,
+    concept_chapter_id INT,
+    concept_achievement_id INT,
+    concept_achievement_name VARCHAR(120),
     PRIMARY KEY (concept_id)
 );
 

--- a/api/src/test/resources/sql/cte_test_seed.sql
+++ b/api/src/test/resources/sql/cte_test_seed.sql
@@ -1,4 +1,4 @@
--- M2 Spec 01 Task 1.5: CTE 단위 테스트 전용 시드
+-- M2 Spec 01 Task 1.5 / Spec 02 Task 1.1: CTE 단위 테스트 전용 시드
 --
 -- 그래프 설계 (ADR 0003 backward 방향: from = 선수, to = 후수):
 --
@@ -15,16 +15,22 @@
 --   depth 3 → {10, 1, 2, 3, 4}
 --   depth 4 → {10, 1, 2, 3, 4, 5}
 --   depth 5 → {10, 1, 2, 3, 4, 5, 6}
+--
+-- chapters 시드: spec-02 findPrerequisiteConcepts (concepts JOIN chapters) 검증용.
+-- 모든 concept 은 단일 chapter_id=1 을 참조하여 JOIN 결과를 단순화.
 
-INSERT INTO concepts (concept_id, concept_name) VALUES
-    (1,  'depth-1 prerequisite'),
-    (2,  'depth-1 prerequisite (alt)'),
-    (3,  'depth-2 prerequisite (multi-path)'),
-    (4,  'depth-3 prerequisite'),
-    (5,  'depth-4 prerequisite'),
-    (6,  'depth-5 prerequisite'),
-    (7,  'isolated node'),
-    (10, 'start node');
+INSERT INTO chapters (chapter_id, chapter_name, school_level, grade_level, semester, chapter_main, chapter_sub) VALUES
+    (1, 'cte-test-chapter', '초등', '초1', '1학기', '', '9까지의 수');
+
+INSERT INTO concepts (concept_id, concept_name, concept_description, concept_chapter_id, concept_achievement_id, concept_achievement_name) VALUES
+    (1,  'depth-1 prerequisite',             'desc 1',  1, 1, 'achievement 1'),
+    (2,  'depth-1 prerequisite (alt)',       'desc 2',  1, 1, 'achievement 1'),
+    (3,  'depth-2 prerequisite (multi-path)','desc 3',  1, 1, 'achievement 1'),
+    (4,  'depth-3 prerequisite',             'desc 4',  1, 1, 'achievement 1'),
+    (5,  'depth-4 prerequisite',             'desc 5',  1, 1, 'achievement 1'),
+    (6,  'depth-5 prerequisite',             'desc 6',  1, 1, 'achievement 1'),
+    (7,  'isolated node',                    'desc 7',  1, 1, 'achievement 1'),
+    (10, 'start node',                       'desc 10', 1, 1, 'achievement 1');
 
 INSERT INTO knowledge_space (knowledge_space_id, to_concept_id, from_concept_id) VALUES
     (1, 10, 1),  -- 1 → 10

--- a/docs/specs/m2/spec-02-service-integration-and-caching.md
+++ b/docs/specs/m2/spec-02-service-integration-and-caching.md
@@ -76,7 +76,9 @@ public class ConceptService {
 
     private final RedisUtil redisUtil;
     private final Optional<MysqlConceptRepository> mysqlConceptRepository;
-    private static final long TTL_24H = Duration.ofHours(24).toSeconds();
+    // RedisUtil.set(key, o, duration) 의 duration 은 MILLISECONDS 단위 (TimeUnit.MILLISECONDS).
+    // toSeconds() 사용 시 86.4초만 캐싱되어 의도(24h)와 불일치.
+    private static final long TTL_24H = Duration.ofHours(24).toMillis();
 
     @Value("${mmt.migration.use-mysql-cte-for-graph:false}")
     private boolean useMysqlCte;


### PR DESCRIPTION
## Summary

- ConceptService 5개 그래프 메서드 + KnowledgeSpaceService에 CTE 분기 + RedisUtil 캐싱 확산 (M1 시범 → 본격)
- ADR 0006 객체 반환 메서드 (`findPrerequisiteConcepts`) `concepts JOIN chapters` 패턴으로 추가
- 캐시 무효화 endpoint (`POST /admin/cache/graph/invalidate`) + RedisUtil prefix 일괄 삭제 (SCAN)
- Testcontainers Redis 컨테이너 + 사전 존재 실패 테스트 정상화

## Spec-02 Task 매핑

| Task | Status | 커밋 |
|------|--------|------|
| 2.1 RedisUtil 직접 호출 캐싱 (ADR 0004) | ✅ | b7c51f3 |
| 2.2 캐시 TTL + 무효화 endpoint | ✅ | b7c51f3 |
| 3.1 분기 적용 (5 메서드 + KS) | ✅ | b7c51f3 |
| 3.2 `.block()` 위치 식별 | ✅ | spec-03 코드 삭제 |
| 3.3 학교 수준 분기 호환 | ✅ | b7c51f3 |

## 분기 매트릭스

| 메서드 | 위치 | CTE 호출 | 캐시 키 |
|--------|------|----------|---------|
| `findToConcepts` | ConceptService | `findPrerequisiteConcepts(?, 1)` + self filter | `graph:to-concepts:<id>` |
| `findNodesByConceptId` | ConceptService | `findPrerequisiteConcepts(?, depth)` | `graph:prerequisites:objs:<id>:<depth>` |
| `findNodesIdByConceptIdDepth2/3/5` | ConceptService | `findPrerequisiteConceptIds(?, depth)` | `graph:prerequisites:ids:<id>:<depth>` |
| `findEdgesByConceptId` | KnowledgeSpaceService | (옵션 B) ConceptService 경유 | inherited |

## 핵심 결정

- **`findToConcepts` 의미 차이 보정** — Cypher `(n)-[r]->(m{?})` 는 `m` 미포함, CTE depth=1 은 자기 포함. 시작 노드 필터로 정합성 확보 (commit b7c51f3, ConceptService.java:84)
- **POJO 캐싱** — `Jackson2JsonRedisSerializer` 가 default typing 미적용으로 `List<Concept>` 라운드트립 시 `LinkedHashMap` 으로 떨어짐. ObjectMapper JSON 문자열 변환으로 우회 (`cachedConceptsOrCompute`)
- **KnowledgeSpaceService 옵션 B 채택** — ConceptService 경유로 분기·캐싱 자동 상속, 분기 코드 중복 제거. ConceptService → KS 역참조 없음 확인 (회로 부재)
- **TTL 단위 버그 정정** — spec-02 예시 `Duration.ofHours(24).toSeconds()` (= 86400초로 의도, 실제 86.4초 캐싱) → `.toMillis()` (RedisUtil:19 의 `TimeUnit.MILLISECONDS` 와 일치)

## .block() 위치 (spec-03 에서 삭제)

- `ProbabilityService.java:66`
- `KnowledgeSpaceService.java:38`

본 PR 에서는 분기 분기점만 조정 (CTE 경로일 때 `Flux.fromIterable` 동기 결과로 `.block()` 자연 우회). 코드 자체 삭제는 spec-03 Task 5.3 (Neo4j 폐기) 에서 일괄 처리.

## 사전 존재 테스트 정상화

`ApiApplicationTests`, `RedisUtilTest` 는 plain `@SpringBootTest` 로 작성되어 호스트 MySQL/Neo4j/Redis 가 떠 있지 않으면 실패하던 상태. TestcontainersConfig 에 Redis 컨테이너를 추가한 김에 두 테스트도 `@Import(TestcontainersConfig.class)` 로 라우팅하여 hermetic 하게 실행되도록 보강.

## Test plan

- [x] `./gradlew test` 60 passed / 0 failed
- [x] `MysqlConceptRepositoryCteTest` (14) — 객체 반환 메서드 6 케이스 추가
- [x] `ConceptServiceCacheTest` (7) — Mockito 캐시 hit/miss/invalidate
- [x] `ConceptServiceCteIntegrationTest` (5) — `@SpringBootTest` + flag=true
- [x] `ConceptServiceFeatureFlagTest` — Neo4j fallback 회귀 보호 유지
- [ ] 로컬 `bootRun` 으로 `/admin/cache/graph/invalidate` 수동 호출 (관리자 인증 필요)
- [ ] spec-03 에서 M1 스냅샷 대비 정확성 + 캐시 히트율 측정

## Analyze-Before-Change 결과

- 영향 범위: ConceptService 5 메서드 + KnowledgeSpaceService + RedisUtil + ConceptController 6 endpoints (간접) + 신규 AdminCacheController. 프론트 응답 DTO 동일 → web/ 무영향
- 위험도: 중간 — 표면적 큼, 단 기본값 false (Neo4j fallback) 즉시 롤백 가능
- 롤백: `mmt.migration.use-mysql-cte-for-graph=false` 토글 (재배포 불필요 시 환경변수)

## 비범위 (spec-03)

- M1 스냅샷 대비 정확성 검증
- 성능 + 캐시 히트율 측정
- Cytoscape.js / BFS 호환 검증
- `.block()` 코드 삭제
- Neo4j 인프라 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)