### PR TITLE
docs: restart m2 with corrected knowledge_space edge direction

### DIFF
--- a/docs/adr/0003-m2-caching-pattern.md
+++ b/docs/adr/0003-m2-caching-pattern.md
@@ -1,0 +1,68 @@
+# ADR 0003: M2 캐싱 패턴 — RedisUtil 직접 호출, Spring Cache 미도입
+
+## Status
+
+Accepted
+
+## Context
+
+Milestone 2의 CTE 성능 보상 수단으로 캐싱이 필요하다. spec-02 1차 작성에서는 Spring Cache(`@Cacheable`/`@CacheEvict` + `RedisCacheManager` Bean)를 가정했으나, audit에서 다음 사실이 확인됐다:
+
+- 현재 프로젝트에 Spring Cache 인프라 미도입 — `@EnableCaching`/`@Cacheable`/`RedisCacheManager` 모두 부재
+- Redis는 `RedisUtil`(`api/src/main/java/com/mmt/api/util/RedisUtil.java`)을 통한 직접 호출 패턴으로만 사용 중 (JWT 토큰 저장 용도)
+- Spring Cache 도입 시 `@EnableCaching` + `RedisCacheManager` Bean 등록 + 직렬화 설정 + `condition` SpEL 검증 등 신규 인프라 작업이 추가됨 (M2 범위 확장)
+
+본 ADR은 M2 캐싱 패턴을 단일 결정으로 고정한다.
+
+## Decision
+
+M2의 그래프 쿼리 캐싱은 **`RedisUtil` 직접 호출 패턴**을 채택한다. Spring Cache(`@Cacheable`)는 도입하지 않는다.
+
+캐싱 적용 형태:
+
+```java
+public List<Integer> findPrerequisiteCached(int conceptId, int maxDepth) {
+    String key = "graph:prerequisites:" + conceptId + ":" + maxDepth;
+    @SuppressWarnings("unchecked")
+    List<Integer> cached = (List<Integer>) redisUtil.get(key);
+    if (cached != null) return cached;
+
+    List<Integer> result = mysqlConceptRepository.get()
+        .findPrerequisiteConceptIds(conceptId, maxDepth);
+    redisUtil.set(key, result, TTL_24H);
+    return result;
+}
+```
+
+규약:
+- 키 prefix `graph:prerequisites:` (메서드별 추가 prefix로 분리: `graph:nodes-by-concept:`, `graph:to-concepts:`)
+- TTL 24시간 (`TTL_24H` 상수)
+- 무효화: 운영자 수동 endpoint에서 prefix 기반 일괄 삭제 또는 TTL 자연 만료
+
+## Consequences
+
+### Positive
+- 기존 Redis 사용 패턴(`RedisUtil`)과 일관성 유지 — 새 컨벤션 학습 비용 없음
+- M2 범위가 spec-02 본 목적(분기·캐싱)에 집중되며 인프라 도입 작업이 사라져 일정 단축
+- `condition` SpEL 검증, 빈 등록 순서, 자동 직렬화 동작 검증 등 부수적 디버깅 부담 제거
+- 캐시 hit/miss 로직이 메서드 본문에 명시적으로 보여 디버깅·로깅이 단순
+
+### Negative
+- 캐시 적용 메서드마다 본문에 if-else 6줄이 반복됨 (어노테이션보다 verbose)
+- 향후 캐시 정책 변경 시 메서드별 수정 필요 (어노테이션이라면 한 줄 수정)
+
+### Neutral
+- 향후 모니터링·운영 자동화 도입 마일스톤(M3 권장 — ADR 0004 참조)에서 Spring Cache로 승격할 수 있음. 본 ADR은 M2 범위에 한정한 결정이며, 향후 결정으로 대체 가능
+
+## Alternatives Considered
+
+1. **Spring Cache(`@Cacheable`) + `RedisCacheManager` Bean 도입** — 기각. 인프라 신규 도입 작업이 spec-02 범위를 벗어나며, `condition` SpEL로 인스턴스 필드(`useMysqlCte`)에 접근하는 동작 검증이 추가 부담. M2 핵심 목적(Neo4j 제거)과 무관한 작업.
+2. **캐싱 없이 CTE 단독 사용** — 기각. CTE 깊이 5의 p95 허용치(<100ms)가 M1 baseline 대비 7.7배 허용임에도 캐시 미스 비율이 높으면 사용자 체감 회귀 가능.
+3. **외부 캐시 라이브러리 (Caffeine 등) 도입** — 기각. 단일 인스턴스 환경 가정이 명확하지 않고, Redis가 이미 가용하므로 in-memory 캐시 별도 도입 불필요.
+
+## References
+
+- `api/src/main/java/com/mmt/api/util/RedisUtil.java` — 기존 Redis 사용 패턴
+- 적용 spec: `docs/specs/m2/spec-02-service-integration-and-caching.md` Task 2.1·2.2
+- 관련 ADR: ADR 0002 §1 (피처 플래그 네임스페이스 — 캐시 키 prefix `graph:*`은 별개 영역)
+- 후속 결정 가능: M3에서 Spring Cache 승격 검토 (모니터링 인프라 도입 시 동시 진행 가능)

--- a/docs/adr/0004-m2-monitoring-deferred.md
+++ b/docs/adr/0004-m2-monitoring-deferred.md
@@ -1,0 +1,58 @@
+# ADR 0004: M2 production 모니터링 인프라 — M3로 분리, M2는 SimpleMeterRegistry 검증 단계만 유지
+
+## Status
+
+Accepted
+
+## Context
+
+Milestone 2 spec-03 Task 4.2의 모니터링 인프라 의사결정에서 다음 사실이 확인됐다:
+
+- M1에서 도입한 `SimpleMeterRegistry`(ADR 0002 §4)는 in-memory 누적 구현으로 단위 테스트·로컬 검증용임. production 모니터링(p95 trends, 에러율 alerting, 캐시 hit율 dashboard 등)에는 부족.
+- production 모니터링을 본격 도입하려면 Prometheus + Grafana 또는 동등 인프라 + Spring Boot Actuator 승급이 필요하며, 이는 신규 인프라 도입·보안 설정·dashboard 설계 등 M2 핵심(Neo4j 제거)과 결이 다른 작업을 동반함.
+- ADR 0002 §4는 이미 "추후 Prometheus·Grafana 로드맵 진입 시 Actuator로 승급"을 명시함.
+
+본 ADR은 M2의 모니터링 작업 범위를 단일 결정으로 고정한다.
+
+## Decision
+
+M2 범위에서는 **production 모니터링 인프라 도입을 수행하지 않는다.** spec-03 Task 4.2의 검증 단계는 M1에서 도입한 `SimpleMeterRegistry` + 로그 기반 측정으로 진행하며, production 모니터링 인프라(Prometheus + Grafana + Actuator 등)는 별도 마일스톤 **M3 (가칭: 운영 관측성 도입)** 으로 분리한다.
+
+M2 spec-03 검증 범위:
+- 회귀 테스트 (Task 4.1) — 단위 테스트 + Testcontainers
+- 성능 체크포인트 (Task 4.2) — `SimpleMeterRegistry` 메트릭 + `QueryTimingAspect` 슬로우 쿼리 WARN 로그
+- 캐시 동작 (spec-02 Task 2.1) — 단위 테스트
+- 부하 테스트 (Task 4.2) — k6 신규 시나리오, 결과는 PR 설명에 첨부
+
+M2 비범위 (M3 후행):
+- production 환경의 p95 trend dashboard
+- 에러율 alerting
+- 캐시 hit율 실시간 모니터링
+- Prometheus metrics endpoint 노출
+- Grafana dashboard 구성
+
+## Consequences
+
+### Positive
+- M2 범위가 "Neo4j 제거" 핵심에 집중되어 일정 예측 가능
+- spec-03 Task 4.2의 모니터링 인프라 의사결정이 사라져 spec 실행 시 결정 부담 제거
+- ADR 0002 §4의 일관성 유지 (Actuator 미도입 정책)
+
+### Negative
+- M2 운영 1개월 관찰 기간(spec-03 완료 기준)에 production 메트릭 dashboard가 없으므로, 회귀·이상 감지가 로그 기반으로만 이루어짐 → 즉각적 alerting 부재
+- 사고 대응 시 측정 데이터 수집이 ad-hoc (로그 grep·수동 측정)
+
+### Neutral
+- M3는 본 ADR 시점에 일정·우선순위 미확정 — roadmap의 Later 섹션에 등재 권장
+
+## Alternatives Considered
+
+1. **M2에 Prometheus + Grafana 도입 포함** — 기각. M2 핵심(Neo4j 제거)과 결이 다르며 작업량·일정 위험 증가. Actuator 도입은 자동설정·HTTP 엔드포인트·보안 설정 영향 범위가 커서 ADR 0002 §4와도 충돌.
+2. **로그 기반 측정만으로 운영 단계까지 진행 (M3 미신설)** — 기각. M2 이후 다른 마이그레이션·기능에서도 dashboard·alerting이 반복적으로 필요해질 가능성 높음. M3로 명시적으로 분리하여 후속 작업의 진입점으로 둔다.
+
+## References
+
+- 선행 ADR: ADR 0002 §4 (M1 MeterRegistry 결정 — `SimpleMeterRegistry` 수동 등록, Actuator 미도입)
+- 적용 spec: `docs/specs/m2/spec-03-validation-and-rollout.md` Task 4.2
+- 후속 마일스톤 후보: M3 (운영 관측성 도입) — roadmap의 Later 섹션에 등재 예정
+- 관련 자료: `api/src/main/java/com/mmt/api/observability/` (현재 가용 인프라)

--- a/docs/adr/0005-cte-object-mapping-evidence.md
+++ b/docs/adr/0005-cte-object-mapping-evidence.md
@@ -1,0 +1,234 @@
+# ADR 0005 보조 자료 — grep 결과 및 매핑 분석
+
+본 문서는 ADR 0005(MySQL CTE 객체 반환 메서드의 도메인 매핑) 결정의 근거가 된 코드베이스 조사 결과를 보존한다. ADR 본문은 결정·근거·결과만 다루고, 검증에 사용한 raw 데이터는 본 문서에 둔다.
+
+조사 일자: 2026-04-30
+조사자: Claude Code (Robin 검토 후 커밋)
+
+---
+
+## 1. ConceptResponse 13개 필드 (전수)
+
+`api/src/main/java/com/mmt/api/dto/concept/ConceptResponse.java`:
+
+```java
+private int conceptId;
+private String conceptName;
+private String conceptDescription;
+private String conceptSchoolLevel;
+private String conceptGradeLevel;
+private String conceptSemester;
+private int conceptChapterId;
+private String conceptChapterName;
+private String conceptChapterMain;
+private String conceptChapterSub;
+private int conceptAchievementId;
+private String conceptAchievementName;
+private String conceptSection;
+```
+
+## 2. ConceptConverter 두 변환 메서드 비교
+
+`api/src/main/java/com/mmt/api/dto/concept/ConceptConverter.java`:
+
+| 필드 | `convertToFluxConceptResponse` (그래프) | `convertToConceptResponse` (단일 조회) |
+|---|---|---|
+| conceptId | ✓ | ✓ |
+| conceptName | ✓ | ✓ |
+| conceptDescription | ✓ | ✓ |
+| conceptSchoolLevel | ✓ | ✓ |
+| conceptGradeLevel | ✓ | ✓ |
+| conceptSemester | ✓ | ✓ |
+| conceptChapterId | ✓ | ✗ |
+| conceptChapterName | ✓ | ✓ |
+| conceptChapterMain | ✓ | ✓ |
+| conceptChapterSub | ✓ | ✓ |
+| conceptAchievementId | ✓ | ✗ |
+| conceptAchievementName | ✓ | ✓ |
+| conceptSection | ✓ | **✗** |
+
+핵심 관찰: 단일 조회 경로(이미 MySQL 사용 중)는 `conceptSection`을 매핑하지 않음.
+
+## 3. prior art — `findOneByConceptId`의 RowMapper 패턴
+
+`api/src/main/java/com/mmt/api/repository/concept/JdbcTemplateConceptRepository.java`:
+
+```java
+public Concept findOneByConceptId(int conceptId) {
+    String sql = "SELECT c.concept_id, c.concept_name, c.concept_description, " +
+                 "       c.concept_achievement_name, " +
+                 "       ch.school_level, ch.grade_level, ch.semester, " +
+                 "       ch.chapter_main, ch.chapter_sub, ch.chapter_name \n" +
+                 "FROM concepts c JOIN chapters ch ON c.concept_chapter_id = ch.chapter_id " +
+                 "WHERE c.concept_id = ?";
+    return jdbcTemplate.queryForObject(sql, conceptRowMapper(), conceptId);
+}
+
+public String findSchoolLevelByConceptId(int conceptId){
+    String sql = "SELECT ch.school_level FROM chapters ch " +
+                 "JOIN concepts c ON ch.chapter_id = c.concept_chapter_id " +
+                 "WHERE c.concept_id = ?";
+    return jdbcTemplate.queryForObject(sql, String.class, conceptId);
+}
+```
+
+핵심 관찰: `concepts JOIN chapters ON c.concept_chapter_id = ch.chapter_id` 패턴이 이미 정착되어 있고 `concept_id`로 단일 row를 가져온다. CTE 메서드는 이 JOIN을 재귀 결과 집합에 적용하기만 하면 됨.
+
+## 4. concepts / chapters 테이블 스키마 + 시드 샘플
+
+### 4-1. DDL (`api/sql/create.sql`)
+
+```sql
+CREATE TABLE concepts (
+    concept_id INT,
+    concept_name VARCHAR(70),
+    concept_description TEXT,
+    concept_chapter_id INT,
+    concept_achievement_id INT,
+    concept_achievement_name VARCHAR(120),
+    skill_id INT,
+    PRIMARY KEY (concept_id),
+    FOREIGN KEY (concept_chapter_id) REFERENCES chapters (chapter_id)
+);
+
+CREATE TABLE chapters (
+    chapter_id INT,
+    chapter_name VARCHAR(50),
+    school_level VARCHAR(5),
+    grade_level VARCHAR(5),
+    semester VARCHAR(5),
+    chapter_main VARCHAR(50),
+    chapter_sub VARCHAR(50),
+    PRIMARY KEY (chapter_id)
+);
+```
+
+`concepts`의 6개 컬럼 + `chapters`의 6개 컬럼 = 12개. ConceptResponse 13개 중 conceptSection 한 개만 두 테이블에 부재.
+
+### 4-2. chapters 시드 샘플 (`api/sql/insert_chapters.sql`)
+
+컬럼 순서: `(chapter_id, chapter_name, school_level, grade_level, semester, chapter_main, chapter_sub)`
+
+```sql
+INSERT INTO chapters VALUES (1,  '몇일까요 (1)',                 '초등', '초1', '1학기', '', '9까지의 수');
+INSERT INTO chapters VALUES (3,  '몇일까요 (2)',                 '초등', '초1', '1학기', '', '9까지의 수');
+INSERT INTO chapters VALUES (9,  '여러 가지 모양을 찾아볼까요',     '초등', '초1', '1학기', '', '여러 가지 모양');
+INSERT INTO chapters VALUES (11, '모으기와 가르기를 해 볼까요 (1)', '초등', '초1', '1학기', '', '덧셈과 뺄셈');
+INSERT INTO chapters VALUES (14, '더하기는 어떻게 나타낼까요',     '초등', '초1', '1학기', '', '덧셈과 뺄셈');
+```
+
+### 4-3. 컬럼 의미 (시드 분석 결과)
+
+| 컬럼 | 의미 | 운영 시드 관찰 |
+|---|---|---|
+| `chapter_name` | 차시별 학습 활동/소제목 (질문 형태가 흔함) | "몇일까요 (1)", "더하기는 어떻게 나타낼까요" |
+| `school_level` | 학교급 | "초등", "중등", "고등" 추정 |
+| `grade_level` | 학년 | "초1", "초2"... |
+| `semester` | 학기 | "1학기", "2학기" |
+| `chapter_main` | (의미 미상 — 운영 시드에서 빈 문자열) | `''` (전부 빈 값) |
+| `chapter_sub` | 큰 단원명 | "9까지의 수", "여러 가지 모양", "덧셈과 뺄셈" |
+
+**중요 관찰**: 운영 시드에서 `chapter_main`은 모두 빈 문자열로 채워져 있다. spec-02 RowMapper로 가져오면 빈 문자열로 응답되며 프론트(`ResultView.vue:640`)에 그대로 표시될 수 있다 — `{conceptChapterMain}-{conceptChapterSub}-{conceptChapterName}` 포맷에서 첫 부분이 비어 표시됨. 이는 현재 Neo4j 경로도 동일한 결과(`Concept.chapterMain`이 빈 문자열로 매핑됨)이므로 회귀 아님. 본 ADR 결정에는 영향 없음.
+
+## 5. sections / concepts_sections 테이블 (conceptSection 잠재 출처)
+
+```sql
+CREATE TABLE sections (
+    section_id INT,
+    section_name VARCHAR(20),
+    PRIMARY KEY (section_id)
+);
+
+CREATE TABLE concepts_sections (
+    concept_section_id INT auto_increment,
+    concept_id INT,
+    section_id INT,
+    PRIMARY KEY (concept_section_id),
+    FOREIGN KEY (concept_id) REFERENCES concepts (concept_id),
+    FOREIGN KEY (section_id) REFERENCES sections (section_id)
+);
+```
+
+다대다 M:N 관계. 한 conceptId에 여러 section_name 매핑 가능. ConceptResponse의 `conceptSection`은 `String` 단일이므로 평탄화 정책 필요.
+
+## 6. 시드 파일 비교
+
+### `api/sql/insert_concepts.sql` (현재 스키마와 일치, 운영 시드)
+
+```sql
+INSERT INTO concepts VALUES (5814, '1부터 5까지의 수', '...', 1, 1, '...', 8);
+```
+
+7개 컬럼: `concept_id, concept_name, concept_description, concept_chapter_id, concept_achievement_id, concept_achievement_name, skill_id`. chapters 정보(school_level 등)는 별도로 분리되어 있음(정규화).
+
+### `api/sql/insert_concepts_v1.sql` (비활성, Neo4j-style 평탄)
+
+```sql
+INSERT INTO concepts VALUES (5814, '1부터 5까지의 수', '...', '초등', '초1', '1학기', 1, '9까지의 수', '몇일까요 (1)', '', 1, '50까지의수 ...', 8);
+```
+
+13개 컬럼. school_level/grade_level/semester/chapter_*가 평탄하게 들어가 있음. **사용 안 함** — 운영 시드는 정규화 형태.
+
+### `api/sql/insert_concepts_opti.sql` (성능 테스트용, 비활성)
+
+`concept_raw_id` 추가 컬럼 사용. 본 ADR과 무관.
+
+## 7. 단일 필드 accessor 메서드 grep
+
+```
+$ grep -rn "findGradeLevelByConceptId|findSemester|findSection|findChapter" api/src/main/java/
+
+api/src/main/java/com/mmt/api/controller/ChapterController.java:27:
+  return chapterService.findChapters(gradeLevel, semester);
+api/src/main/java/com/mmt/api/service/ChapterService.java:19:
+  public List<ChapterResponse> findChapters(String gradeLevel, String semester){
+```
+
+핵심 관찰: `findGradeLevelByConceptId`, `findSemesterByConceptId`, `findSectionByConceptId` 등 단일 필드 accessor는 **존재하지 않음**. `findSchoolLevelByConceptId`만 단독 존재 — 이는 `findNodesByConceptId`의 학교급 분기에 직접 사용되기 때문(spec-02 audit에서 확인). 다른 필드는 `findOneByConceptId`의 통합 SELECT로만 조회됨.
+
+## 8. 프론트 conceptSection 사용 여부
+
+```
+$ grep -rn "conceptSection|concept_section|\.section" web/src/
+
+(no output)
+```
+
+```
+$ grep -n "concept[A-Z]" web/src/views/ResultView.vue web/src/views/ConceptView.vue
+```
+
+ResultView.vue에서 실제 바인딩되는 필드 (line 번호 포함):
+- line 312: `nodeData.conceptGradeLevel` — cytoscape 노드 색상 결정
+- line 343: `filteredNode.conceptGradeLevel` — cytoscape 데이터 바인딩
+- line 636: `selectedNode1.conceptSchoolLevel`, `conceptGradeLevel`, `conceptSemester` — 상세 패널
+- line 640: `conceptChapterMain`, `conceptChapterSub`, `conceptChapterName` — 상세 패널
+- line 644: `conceptAchievementName` — 상세 패널
+- line 649: `conceptDescription` — 상세 패널
+- line 84/85/115/116/329/337/341/342: `conceptId`, `conceptName` — 식별·라벨
+
+미바인딩 필드: `conceptSection`, `conceptChapterId`, `conceptAchievementId`. 단 id 필드는 응답엔 있지만 화면 표시에는 안 씀.
+
+핵심 관찰: **`conceptSection`은 프론트 어디서도 쓰지 않음**. null 또는 빈 문자열로 두어도 영향 없음.
+
+---
+
+## 종합
+
+| 필드 | concepts JOIN chapters로 도달 | 비고 |
+|---|---|---|
+| conceptId | ✓ | concepts.concept_id |
+| conceptName | ✓ | concepts.concept_name |
+| conceptDescription | ✓ | concepts.concept_description |
+| conceptChapterId | ✓ | concepts.concept_chapter_id |
+| conceptAchievementId | ✓ | concepts.concept_achievement_id |
+| conceptAchievementName | ✓ | concepts.concept_achievement_name |
+| conceptSchoolLevel | ✓ | chapters.school_level |
+| conceptGradeLevel | ✓ | chapters.grade_level |
+| conceptSemester | ✓ | chapters.semester |
+| conceptChapterName | ✓ | chapters.chapter_name |
+| conceptChapterMain | ✓ | chapters.chapter_main |
+| conceptChapterSub | ✓ | chapters.chapter_sub |
+| conceptSection | ✗ | sections JOIN 필요. **프론트 미사용 → 매핑 생략 안전** |
+
+12개 필드는 `findOneByConceptId`의 prior art와 동일 JOIN 패턴으로 즉시 도달 가능. conceptSection 한 개는 매핑 생략하여 단일 조회 경로(`convertToConceptResponse`)와 일관성 유지 — 프론트 영향 0.

--- a/docs/adr/0005-cte-object-mapping.md
+++ b/docs/adr/0005-cte-object-mapping.md
@@ -1,0 +1,96 @@
+# ADR 0005: MySQL CTE 객체 반환 메서드의 도메인 매핑 — `concepts JOIN chapters`, conceptSection 매핑 생략
+
+## Status
+
+Accepted
+
+## Context
+
+Milestone 2 spec-01 진입 직전 audit 과정에서 `Flux<Concept>` 반환 메서드(`findNodesByConceptIdDepth3/5`, `findToConceptsByConceptId`)를 MySQL CTE로 옮길 때 `Concept` 도메인 ↔ MySQL `concepts` 테이블의 컬럼 매핑이 일치하지 않는다는 사실이 발견됐다(분석 1차).
+
+피드백 검토에서 다음이 명확해졌다:
+- spec-01은 ID 반환 메서드(`findPrerequisiteConceptIds`)만 도입하므로 객체 매핑 결정은 spec-01 진입 차단 사유가 아님
+- 옵션 비교 전에 `ConceptResponse`·`ConceptConverter`·프론트 바인딩 3개를 확인해야 결정 가능
+- 7개 부재 필드가 모두 사용된다는 가정은 검증되지 않음
+
+본 ADR은 위 3개 자료와 시드/스키마/단일 필드 accessor를 모두 grep한 결과(보조 자료: ADR 0005 evidence)에 따라 spec-02 진입 전 객체 매핑 정책을 단일 결정으로 고정한다.
+
+## Decision
+
+`MysqlConceptRepository`의 객체 반환 메서드(spec-02에서 도입할 `findPrerequisiteConcepts(int conceptId, int maxDepth)` 등)는 **`concepts JOIN chapters` JOIN 패턴**으로 `Concept` 객체를 매핑한다. `JdbcTemplateConceptRepository.findOneByConceptId`의 prior art를 그대로 확장한다.
+
+매핑 정책:
+
+- **ConceptResponse 13개 필드 중 12개**는 `concepts` + `chapters` 두 테이블 JOIN으로 채운다
+  - `concepts`: conceptId, conceptName, conceptDescription, conceptChapterId, conceptAchievementId, conceptAchievementName
+  - `chapters` (JOIN): conceptSchoolLevel, conceptGradeLevel, conceptSemester, conceptChapterName, conceptChapterMain, conceptChapterSub
+- **`conceptSection`은 매핑 생략** (RowMapper에서 미설정 → null)
+  - 프론트 어디에서도 사용되지 않음 (`web/src/` 전체 grep 0건)
+  - 단일 조회 경로(`ConceptConverter.convertToConceptResponse`)도 이미 conceptSection을 매핑하지 않음 → 일관성 유지
+  - `concepts_sections` 다대다 JOIN과 평탄화 정책이 모두 불필요해짐
+
+CTE 쿼리 형태(spec-02에서 적용):
+
+```sql
+WITH RECURSIVE prerequisite_path AS (
+    SELECT concept_id, 0 AS depth
+    FROM concepts WHERE concept_id = ?    -- 매개변수 1: 시작 conceptId
+
+    UNION ALL
+
+    SELECT c.concept_id, pp.depth + 1
+    FROM prerequisite_path pp
+    JOIN knowledge_space ks ON pp.concept_id = ks.from_concept_id
+    JOIN concepts         c  ON ks.to_concept_id = c.concept_id
+    WHERE pp.depth < ?                    -- 매개변수 2: maxDepth
+)
+SELECT c.concept_id, c.concept_name, c.concept_description,
+       c.concept_chapter_id, c.concept_achievement_id, c.concept_achievement_name,
+       ch.school_level, ch.grade_level, ch.semester,
+       ch.chapter_main, ch.chapter_sub, ch.chapter_name
+FROM (SELECT DISTINCT concept_id FROM prerequisite_path) pp   -- 다중 경로 중복 제거
+JOIN concepts c  ON pp.concept_id = c.concept_id
+JOIN chapters ch ON c.concept_chapter_id = ch.chapter_id;
+```
+
+**중복 제거 주의:** 다중 경로(예: A → Y → W와 A → Z → W가 모두 존재)에서 `prerequisite_path`에 동일 conceptId가 여러 depth로 등장 가능. 외부 SELECT에서 `(SELECT DISTINCT concept_id FROM prerequisite_path)` subquery로 평탄화하지 않으면 ConceptResponse 리스트에 중복 객체가 발생하여 cytoscape 노드 중복으로 이어진다. ID-only CTE(spec-01)는 마지막에 `SELECT DISTINCT concept_id`로 처리하지만, 객체 반환 SELECT는 외부에 DISTINCT 처리가 필수.
+
+**매개변수 바인딩:** prepared statement 2개 매개변수, 순서대로 (1) 시작 `conceptId` (anchor의 WHERE), (2) `maxDepth` (재귀의 WHERE). spec-02의 `findPrerequisiteConcepts(int conceptId, int maxDepth)` 시그니처와 매핑.
+
+`Concept` 도메인 클래스의 `@Node`/`@Property` Neo4j 어노테이션은 본 ADR 시점에 제거하지 않는다 — Neo4j 폐기(spec-03 Task 5.3)에서 일괄 정리.
+
+## Consequences
+
+### Positive
+- 12개 필드가 prior art(`findOneByConceptId`) 패턴 그대로 도달 가능 → spec-02 RowMapper 작성이 단순한 SQL 확장으로 끝남
+- 단일 조회 경로와 그래프 경로의 conceptSection 매핑 정책이 일관됨 (둘 다 미매핑)
+- `concepts_sections`/`sections` 다대다 JOIN, 평탄화 정책(LIMIT 1 vs GROUP_CONCAT) 결정이 모두 불필요해져 spec-02 작업 부담 축소
+- 별도 MySQL 도메인 클래스(옵션 D) 신설 회피 — `Concept` 단일 도메인 유지로 변환 boilerplate 0
+- M2 scope 재정의 발동 안 됨 — 8일 일정 그대로 진행 가능
+
+### Negative
+- `Concept` 도메인의 일부 필드(MySQL `concepts`/`chapters`에 부재한 항목)가 그래프 경로에서도 null로 채워짐 — 프론트 미사용이므로 영향 0이지만 의미상 "노드는 항상 동일 형태"라는 가정이 약해짐. spec-03 Task 5.3에서 Neo4j 어노테이션 제거 시 도메인 정리 함께 진행
+- 객체 반환 경로는 ID 반환 대비 `concepts`·`chapters` 두 테이블 JOIN + N row 패치가 추가됨 → 응답 시간 증가 가능. spec-03 Task 4.2에서 ID 반환과 객체 반환 허용치를 분리해서 측정·기록 권장 (M1 baseline은 두 형태 모두 측정했으나 마일스톤 성능표에 명시적 분리 없음)
+
+### Neutral
+- 향후 진단 결과 페이지 UI 변경으로 `conceptSection` 필요 시점이 오면 ADR 후속 결정으로 sections JOIN 보강. 현재는 미사용 확인됨
+
+## Alternatives Considered
+
+1. **옵션 A — null 허용 (모든 부재 필드를 null로)** — 기각. `chapters` JOIN으로 즉시 도달 가능한 12개 필드 중 10개가 프론트에서 실제 바인딩되고(나머지 2개는 응답엔 있으나 미바인딩의 ID 필드), 채울 수 있는 데이터를 null로 두는 결정은 회귀를 만든다. 본 ADR은 evidence §8 grep 결과로 미바인딩이 확인된 conceptSection만 매핑 생략 (작업 단순화 + 단일 조회 경로와 일관성).
+2. **옵션 B — `concepts` 테이블에 부재 컬럼 추가 + 시드 보강 (스키마 변경)** — 기각. 데이터가 이미 `chapters` 테이블에 정규화 형태로 존재하므로 컬럼 중복. `insert_concepts_v1.sql`의 평탄 시드는 비활성 상태이며 운영 시드(`insert_concepts.sql`)는 정규화 채택. 스키마를 역정규화할 이유 없음.
+3. **옵션 D — MySQL 전용 도메인 클래스(`ConceptRow` 등) 신설** — 기각. 데이터 소싱 문제 자체를 풀지 않고 도메인 분리만 함. 결국 본 ADR과 동일한 JOIN을 어딘가에서 해야 하므로 추가 변환 boilerplate만 발생.
+4. **옵션 E — 객체 반환 메서드 도입 자체를 M2 비범위로** — 기각. `findNodesByConceptId`·`findToConcepts`가 진단 결과 페이지의 핵심 기능이므로 Neo4j 폐기 전제 조건. M2 scope에 반드시 포함되어야 함. 데이터가 이미 MySQL에 있으므로 부분 이연 불필요.
+5. **conceptSection을 GROUP_CONCAT로 합쳐 매핑** — 기각. 프론트 미사용이 확인됐으므로 매핑 자체가 dead code. 정책 결정 부담만 추가.
+6. **conceptSection을 LIMIT 1로 첫 매핑만** — 기각. 위와 동일.
+
+## References
+
+- 결정 근거 raw 데이터: `docs/adr/0005-cte-object-mapping-evidence.md`
+- prior art: `api/src/main/java/com/mmt/api/repository/concept/JdbcTemplateConceptRepository.java` (`findOneByConceptId`, `findSchoolLevelByConceptId`)
+- 매핑 대조: `api/src/main/java/com/mmt/api/dto/concept/ConceptResponse.java`, `ConceptConverter.java`
+- 스키마: `api/sql/create.sql` (`concepts`, `chapters`, `sections`, `concepts_sections`)
+- 프론트 바인딩: `web/src/views/ResultView.vue` (cytoscape 노드 데이터·상세 패널 표시)
+- 적용 spec: `docs/specs/m2/spec-02-service-integration-and-caching.md` (Task 3.1의 객체 반환 메서드 분기 형태)
+- 관련 ADR: ADR 0002 §2 (테스트 프로파일)
+- 후속 정리: spec-03 Task 5.3 (Neo4j 폐기 시 `Concept` 도메인의 `@Node`/`@Property` 어노테이션 제거)

--- a/docs/milestones/milestone-2-neo4j-to-mysql-cte.md
+++ b/docs/milestones/milestone-2-neo4j-to-mysql-cte.md
@@ -1,0 +1,131 @@
+# Milestone 2: Neo4j → MySQL CTE 마이그레이션
+
+**브랜치:** `feat/migrate-neo4j-to-mysql-cte`
+**예상 소요:** 8일 (구현) + 운영 관찰 기간 (기본 1개월)
+**의존성:** Milestone 1 (테스트 인프라 및 기준선 구축) 완료
+**위험 수준:** 중간
+**선행 조건:** Milestone 1의 모든 완료 기준 충족, M1 산출물(기준선·결과 스냅샷·피처 플래그 구조) 가용
+
+---
+
+## 목표
+
+Neo4j 그래프 데이터베이스를 제거하고 MySQL Recursive CTE로 대체한다. 이를 통해:
+
+- AWS 비용 절감 (~월 $50-100) — [검증 필요] 실제 인스턴스 비용
+- 데이터 중복(MySQL ↔ Neo4j) 근본 해소
+- 운영 복잡도 감소 (관리 DB 1개 감소, docker-compose 단순화)
+- 리액티브 안티패턴(`.block()` 호출) 자연 해소
+
+## 왜 이 마일스톤이 최우선인가
+
+- 가장 높은 AWS 비용 절감 효과
+- 변경 범위가 좁음 (리포지토리 1개, 그래프 메서드 군 한정)
+- 데이터 중복 문제의 근본 해결
+- 배포 단순화 (docker-compose에서 Neo4j 컨테이너 제거)
+
+---
+
+## 현재 상태 요약
+
+### Neo4j 사용 범위
+
+**단일 유즈케이스:** 맞춤형 학습 경로를 위한 선수 개념 그래프 탐색
+
+```
+전체 리포지토리 클래스 22개 (도메인 11개; 대부분 JPA + JdbcTemplate 페어) 중
+└── Neo4j (Reactive): 1개 — ConceptRepository (그래프 탐색 Cypher 쿼리)
+```
+
+- **데이터 규모:** 1,631 노드 / 3,446 엣지 — [검증 필요] 실제 production 카운트
+- **호출 빈도:** 진단 결과 페이지 로드 시에만 (낮음) — [검증 필요]
+- **데이터 특성:** 읽기 전용, CSV 초기 로드 후 런타임 변경 없음
+- **핵심 문제:** `Concept` 데이터가 MySQL과 Neo4j에 중복 저장
+
+### M1에서 준비된 자산 (활용 대상)
+
+- 성능 기준선: `docs/benchmark/`
+- Neo4j 결과 스냅샷 (sha256 해시 포함): `shared/benchmark/`
+- 피처 플래그: `mmt.migration.use-mysql-cte-for-graph` (ADR 0002 §1 네임스페이스 준수)
+- ConceptService.findNodesIdByConceptIdDepth3 분기 시범 적용
+- QueryTimingAspect (Hibernate Statistics + SimpleMeterRegistry)
+
+---
+
+## 성능 허용 기준
+
+| 항목 | M1 기준선 (Neo4j) | CTE 허용치 | 비고 |
+|------|-------------------|-----------|------|
+| 깊이 3 (초등학교) | p95 14.034 ms (M1 baseline) | <30ms (p95) | 약 2.1배 허용 |
+| 깊이 5 (고등학교) | p95 12.898 ms (M1 baseline) | <100ms (p95) | 약 7.8배 허용 |
+| 캐시 히트율 | — | >90% (warm-up 후) | [검증 필요] 90% 산출 근거 |
+| 캐시 히트 시간 | — | <5ms | Redis 기준 |
+
+> 비교 일관성: M1 baseline은 **conceptId=6646 단일 ID**로 측정됐다(`docs/benchmark/milestone-1-baseline.md:40,52-56`). spec-03 Task 4.2의 CTE 회귀·부하 측정도 동일 conceptId를 사용해야 깊이 비교가 의미를 가진다. 깊이 5의 p95(12.898ms)가 깊이 3의 p95(14.034ms)보다 작은 것도 이 단일 ID 측정에 따른 서브그래프 특성 + JIT warmup 영향이며, 동일 ID로만 회귀를 비교하면 영향 상쇄.
+
+성능 데이터 원본은 `docs/benchmark/`(M1 산출물)을 참조한다.
+
+---
+
+## 구성 spec
+
+본 마일스톤은 다음 3개 spec으로 분해된다. 각 spec은 별도 세션에서 실행한다.
+
+- **spec-01: CTE 리포지토리 + 인덱스** (Phase 1, 2일)
+  데이터 레이어 한정. JdbcTemplateConceptRepository에 재귀 CTE 메서드와 인덱스 도입.
+- **spec-02: 서비스 통합 + 캐싱 + 리액티브 정리** (Phase 2 + 3, 3일)
+  ConceptService 그래프 메서드 군에 분기·캐싱·`.block()` 정리 적용.
+- **spec-03: 검증 + 점진적 출시 + 폐기** (Phase 4 + 5, 3일 + 관찰 기간)
+  정확성·성능·호환성 검증과 Neo4j 인프라 폐기.
+
+---
+
+## 위험 및 완화
+
+| 위험 | 가능성 | 영향 | 완화 |
+|------|--------|------|------|
+| CTE 성능 미달 (깊이 5) | 중간 | 중간 | Redis 캐싱(>90% 히트율 목표), 복합 인덱스 |
+| 캐싱 레이어 신규 도입 | 낮음 | 낮음 | RedisUtil 직접 호출 채택(ADR 0003)으로 영향 최소화 — Spring Cache 인프라 미도입 |
+| 단일 인스턴스 환경에서 점진 전환 한계 | 중간 | 중간 | spec-03 Task 5.1에서 3가지 안 검토 후 채택 |
+| Cytoscape.js 호환성 | 낮음 | 중간 | 그래프 응답 DTO 형태 동등성 테스트 |
+| BFS 알고리즘 회귀 | 낮음 | 중간 | LogicUtil.bfs 입력 동등성 테스트 |
+| 데이터 정합성 (전환 기간) | 낮음 | 높음 | 정적 데이터 + 피처 플래그 즉시 롤백 |
+| `.block()` 잔존 호출 누락 | 중간 | 낮음 | spec-02에서 전수 조사 후 spec-03에서 제거 |
+
+---
+
+## 기대 효과
+
+- **비용:** AWS Neo4j 호스팅 제거 (~월 $50-100 절약)
+- **운영:** 유지보수·백업·모니터링 대상 DB 1개 감소
+- **일관성:** MySQL ↔ Neo4j 데이터 중복 문제 근본 해결
+- **배포:** docker-compose 단순화 (Neo4j 컨테이너 제거)
+- **기술 부채:** 리액티브 블로킹(`.block()`) 안티패턴 자연 해소
+
+---
+
+## 완료 기준
+
+- [ ] `ConceptRepository`의 그래프 메서드 6개를 모두 CTE로 대체 (매핑 표는 spec-01 사전 조건 참조)
+- [ ] ConceptService 그래프 메서드 5개 모두 피처 플래그 분기 적용 (spec-02)
+- [ ] 캐시 히트율 >90% 확인 (spec-03)
+- [ ] CTE 결과와 M1 Neo4j 스냅샷 정확성 100% 일치
+- [ ] 모든 CTE 쿼리가 성능 허용 기준 충족
+- [ ] 그래프 시각화(Cytoscape.js) / BFS 알고리즘 호환 확인
+- [ ] 피처 플래그로 즉시 롤백 가능
+- [ ] 운영 1개월 무사고 — [검증 필요] 모니터링 인프라 가용성
+- [ ] Neo4j 인프라 완전 제거 (코드·의존성·컨테이너·AWS 인스턴스)
+- [ ] Neo4j 폐기 ADR 작성 (도입 배경과 폐기 사유 함께 기록)
+
+---
+
+## 참조
+
+- ADR 0001: 마이그레이션 전 테스트 커버리지 선행 구축
+- ADR 0002: M1 구현 컨벤션 묶음 (특히 §1 피처 플래그 네임스페이스 준수 필수)
+- ADR 0003: M2 캐싱 패턴 (RedisUtil 직접 호출, Spring Cache 미도입)
+- ADR 0004: M2 모니터링 인프라는 M3로 분리, M2는 SimpleMeterRegistry 검증 단계만
+- ADR 0005: CTE 객체 반환 메서드 도메인 매핑 (`concepts JOIN chapters`)
+- spec-01 데이터 모델 노트: `knowledge_space` 엣지 방향성 정의 (M2 전 SQL의 의미 기준)
+- M1 산출물: `docs/benchmark/`, `shared/benchmark/`
+- 루트 CLAUDE.md: Analyze-Before-Change 패턴 + 피처 플래그 정책

--- a/docs/specs/m2/spec-01-cte-repository-and-indexes.md
+++ b/docs/specs/m2/spec-01-cte-repository-and-indexes.md
@@ -1,0 +1,282 @@
+# Spec 01: CTE 리포지토리 + 인덱스
+
+**상위 마일스톤:** Milestone 2 (Neo4j → MySQL CTE 마이그레이션)
+**대상 Phase:** Phase 1
+**예상 소요:** 2일
+**선행 spec:** —
+
+---
+
+## 범위
+
+`JdbcTemplateConceptRepository`에 재귀 CTE 메서드를 추가하고, 성능 확보에 필요한 인덱스를 도입한다. 본 spec은 **데이터 레이어에 한정**되며, 서비스 레이어 통합·피처 플래그 분기·캐싱은 spec-02, 검증·출시·폐기는 spec-03 범위다.
+
+---
+
+## 📌 데이터 모델 노트 — `knowledge_space` 엣지 방향성
+
+> **본 노트는 M2 전 spec(01·02·03)의 모든 SQL과 테스트 단정에 적용되는 의미 정의다. SQL 작성·해석 시 항상 이 노트를 기준으로 한다.**
+
+### 컬럼 의미 (코드와 시드로부터 도출됨, 결정이 아닌 사실)
+
+| 컬럼 | 의미 |
+|---|---|
+| `from_concept_id` | **후수** (해당 엣지에서 학습 시간상 뒤에 오는 개념) |
+| `to_concept_id` | **선수** (해당 엣지에서 학습 시간상 앞서야 하는 개념) |
+
+### 근거 1 — Neo4j 적재 코드
+
+`api/src/test/java/com/mmt/api/performance/GraphQueryPerformanceTest.java`의 `LOAD CSV`:
+
+```cypher
+LOAD CSV WITH HEADERS FROM 'file:///knowledge_space.csv' AS row
+MATCH (a:concept {concept_id: toInteger(row.to_concept_id)}),
+      (b:concept {concept_id: toInteger(row.from_concept_id)})
+CREATE (a)-[:KNOWLEDGE_SPACE]->(b)
+```
+
+엣지는 **`to_concept_id 노드 → from_concept_id 노드`** 방향으로 생성된다. 즉 그래프 화살표의 방향과 컬럼 이름의 방향이 정반대.
+
+### 근거 2 — Cypher 쿼리 의미
+
+`ConceptRepository.findToConceptsByConceptId`:
+
+```cypher
+MATCH (n)-[r]->(m{concept_id: $conceptId}) RETURN (n)
+```
+
+`m`으로 들어오는 엣지의 시작점 `n`을 반환. M1 baseline 작성자가 이를 "선수 개념 조회 (들어오는 엣지)"로 명시 정의(`docs/benchmark/milestone-1-baseline.md:56`).
+
+위 두 근거를 결합:
+- 그래프 엣지: `to_id_node → from_id_node`
+- "들어오는 엣지의 시작점 = 선수" → 그래프에서 화살표가 출발하는 쪽이 선수
+- 따라서 **`to_concept_id` = 선수**, **`from_concept_id` = 후수**
+
+### Trace — 시드 한 행으로 의미 검증
+
+시드 `(id=1, to_concept_id=4659, from_concept_id=3)`:
+
+```mermaid
+graph LR
+    T[concept 4659<br/>to_concept_id<br/>= 선수]
+    F[concept 3<br/>from_concept_id<br/>= 후수]
+    T -->|KNOWLEDGE_SPACE| F
+```
+
+- Cypher `MATCH (n)-[r]->(m{concept_id: 3}) RETURN n` → `[4659]` (concept 3의 선수)
+- 의미: "concept 3을 학습하기 전에 concept 4659를 먼저 학습해야 한다"
+
+### MySQL CTE에의 적용
+
+"X의 선수를 N단계까지 거슬러 올라가기" 쿼리:
+- 시작 노드의 `concept_id`를 **현재 노드 = 후수** 위치로 잡음 → `pp.concept_id = ks.from_concept_id`
+- 다음 단계로 **선수**(`ks.to_concept_id`)를 가져옴
+
+```sql
+JOIN knowledge_space ks ON pp.concept_id = ks.from_concept_id  -- 현재=후수
+JOIN concepts        c  ON ks.to_concept_id = c.concept_id     -- 다음=선수
+```
+
+이 JOIN 패턴은 spec-01·02·03의 모든 CTE와 ADR 0005의 객체 반환 SQL 예시에 동일하게 적용된다.
+
+---
+
+## 사전 조건 / 검증 필요
+
+- ✓ `api/sql/select.sql:285`에 CTE 프로토타입 실재 확인 (`WITH RECURSIVE path AS ...`, conceptId=4979 하드코딩). 본 spec의 출발점.
+- ✓ `JdbcTemplateConceptRepository` 위치: `api/src/main/java/com/mmt/api/repository/concept/JdbcTemplateConceptRepository.java`. 그래프 메서드는 부재. 기존 메서드 명명 패턴은 `find{무엇}By{기준}` (예: `findOneByConceptId`, `findAllByChapterId`, `findSchoolLevelByConceptId`, `findSkillIdByConceptId`). 본 spec에서 신규 도입할 메서드도 동일 패턴을 따른다.
+- ✓ 스키마 확인 (`api/sql/create.sql:52-58`): `knowledge_space(knowledge_space_id INT PK, to_concept_id INT FK, from_concept_id INT FK)`. `concepts.concept_id`도 INT.
+- ✓ DB 마이그레이션 도구 미도입 — `api/sql/`의 수동 SQL 스크립트로 관리(DDL은 `create.sql`, 시드는 `insert_*.sql`). 본 spec의 인덱스 추가·`cte_max_recursion_depth` 설정은 (A) `api/sql/`에 신규 스크립트로 추가하거나 (B) Hikari `connection-init-sql`로 적용.
+
+### ConceptService ↔ ConceptRepository ↔ CTE 매핑 표
+
+ConceptService(5개 그래프 메서드)와 ConceptRepository(6개 Cypher 그래프 메서드)의 매핑. 본 spec(spec-01)은 **ID 반환 메서드 한정**이고, 객체 반환은 spec-02에서 ADR 0005의 JOIN 패턴으로 처리:
+
+| ConceptService (5) | ConceptRepository (6) | 깊이 | 반환 타입 | 처리 spec |
+|---|---|---|---|---|
+| `findNodesByConceptId` (초등) | `findNodesByConceptIdDepth3` | 3 | `Flux<Concept>` | spec-02 (ADR 0005) |
+| `findNodesByConceptId` (그 외) | `findNodesByConceptIdDepth5` | 5 | `Flux<Concept>` | spec-02 (ADR 0005) |
+| `findNodesIdByConceptIdDepth2` | `findNodesIdByConceptIdDepth2` | 2 | `Flux<Integer>` | **spec-01** — `findPrerequisiteConceptIds(?, 2)` |
+| `findNodesIdByConceptIdDepth3` | `findNodesIdByConceptIdDepth3` | 3 | `Flux<Integer>` | **spec-01** — `findPrerequisiteConceptIds(?, 3)` |
+| `findNodesIdByConceptIdDepth5` | `findNodesIdByConceptIdDepth5` | 5 | `Flux<Integer>` | **spec-01** — `findPrerequisiteConceptIds(?, 5)` |
+| `findToConcepts` | `findToConceptsByConceptId` | 1 | `Flux<Concept>` | spec-02 (ADR 0005, 깊이 1 == 직접 선수) |
+
+본 spec은 위 매핑 중 **ID 반환 3 row**에 대응하는 단일 CTE 메서드를 도입한다:
+- `findPrerequisiteConceptIds(int conceptId, int maxDepth)` — `List<Integer>` 반환
+
+객체 반환 메서드(`findPrerequisiteConcepts`) + `RowMapper<Concept>` 매핑은 spec-02에서 ADR 0005의 `concepts JOIN chapters` 패턴으로 처리.
+
+---
+
+## Task 1.1 — 재귀 CTE 메서드 도입
+
+> JOIN 방향은 위 [데이터 모델 노트](#-데이터-모델-노트--knowledge_space-엣지-방향성) 의미 정의를 따른다. `from_concept_id`=후수, `to_concept_id`=선수.
+
+### Neo4j 쿼리 3종 → MySQL CTE 매핑
+
+`api/sql/select.sql:285`의 CTE 프로토타입을 기반으로 깊이 매개변수만 변수화하여 통합 메서드 형태로 정착시킨다.
+
+**쿼리 1 — 직접 선수 개념 (depth 1)**
+
+Neo4j 원본:
+```cypher
+MATCH (n)-[r]->(m{concept_id: $conceptId}) RETURN (n)
+```
+
+MySQL 변환 (X의 직접 선수: `from=X`인 행의 `to`):
+```sql
+SELECT c.* FROM concepts c
+JOIN knowledge_space ks ON c.concept_id = ks.to_concept_id
+WHERE ks.from_concept_id = ?
+```
+
+**쿼리 2 — 깊이 N 재귀 탐색 (핵심)**
+
+Neo4j 원본:
+```cypher
+MATCH (n)-[*0..N]->(m {concept_id: $conceptId}) RETURN (n)
+```
+
+MySQL 변환 (시작 노드를 후수로 잡고, 선수 방향으로 N단계 거슬러 올라감):
+```sql
+WITH RECURSIVE prerequisite_path AS (
+    SELECT concept_id, 0 AS depth
+    FROM concepts WHERE concept_id = ?
+
+    UNION ALL
+
+    SELECT c.concept_id, pp.depth + 1
+    FROM prerequisite_path pp
+    JOIN knowledge_space ks ON pp.concept_id = ks.from_concept_id  -- 현재=후수
+    JOIN concepts c           ON ks.to_concept_id = c.concept_id   -- 다음=선수
+    WHERE pp.depth < ?
+)
+SELECT DISTINCT concept_id FROM prerequisite_path
+```
+
+쿼리 1은 쿼리 2의 `maxDepth=1` 호출과 동일 결과이므로 **별도 메서드 불필요** — `findPrerequisiteConceptIds(?, 1)` 또는 `findPrerequisiteConcepts(?, 1)` 호출로 처리한다.
+
+**쿼리 3 — 경로 상의 concept_id 추출 (BFS 입력용)**
+
+쿼리 2와 동일한 결과셋. 별도 메서드를 두지 않고 쿼리 2 결과를 BFS 입력으로 그대로 사용.
+
+### 메서드 시그니처
+
+`MysqlConceptRepository`(M1 도입)는 이미 다음 메서드를 인터페이스에 정의해두었다:
+
+```java
+public List<Integer> findPrerequisiteConceptIds(int conceptId, int maxDepth);
+```
+
+본 spec은 이 메서드의 **실제 CTE 구현**을 작성한다. 현재 `MysqlConceptRepositoryStub`이 `UnsupportedOperationException`을 던지는 형태로 등록되어 있으니 이를 신규 구현 클래스로 대체한다.
+
+객체 반환 메서드(`findPrerequisiteConcepts`)는 spec-02에서 ADR 0005의 `concepts JOIN chapters` 패턴으로 추가한다.
+
+---
+
+## Task 1.2 — 편의 메서드 도입 결정 (변경됨: 미도입)
+
+기존 Neo4j 쪽이 `findNodesIdByConceptIdDepth2/3/5`로 분리된 이유는 Cypher의 깊이 매개변수가 리터럴만 허용하기 때문. CTE는 매개변수화 가능하므로 통합 메서드 하나로 충분하다.
+
+**결정: 편의 메서드 미도입.** M1 시범 분기 패턴(`ConceptService.java:73-80`)이 통합 메서드 + 깊이 인자 형태 `findPrerequisiteConceptIds(conceptId, 3)`를 채택했으므로, 본 spec도 통합 메서드만 도입하여 spec-02의 분기 적용과 정합성을 유지한다.
+
+호출부 사용 깊이 확인 결과: 2/3/5 세 가지만 사용 (그 외 값 없음). 통합 메서드의 `maxDepth` 인자로 모두 처리 가능.
+
+---
+
+## Task 1.3 — 인덱스 도입
+
+```sql
+CREATE INDEX idx_knowledge_space_from ON knowledge_space(from_concept_id);
+CREATE INDEX idx_knowledge_space_to   ON knowledge_space(to_concept_id);
+CREATE INDEX idx_knowledge_space_composite
+    ON knowledge_space(from_concept_id, to_concept_id);
+```
+
+[검증 필요]
+- 위 인덱스 또는 동등 인덱스가 이미 존재하는지: `SHOW INDEX FROM knowledge_space`
+- PRIMARY KEY 또는 UNIQUE 제약이 동일 컬럼 조합을 커버하는지
+- 참고: `create.sql:52-58`의 `knowledge_space`는 `PRIMARY KEY(knowledge_space_id)` + FK 2개만 명시. MySQL은 FK 컬럼에 자동 인덱스를 생성하므로 단일 인덱스 2개(`from_concept_id`, `to_concept_id`)는 사실상 이미 존재할 가능성이 높음 → **신규는 복합 인덱스 1개일 가능성**. `SHOW INDEX`로 중복 회피 후 결정.
+- 적용 위치: 마이그레이션 도구 미도입(사전 조건 참조) → `api/sql/`에 신규 SQL 스크립트(예: `add_knowledge_space_indexes.sql`)로 추가하고 PR에 적용 절차 명시.
+
+`EXPLAIN`으로 쿼리 2의 실행 계획에서 재귀 단계마다 `idx_knowledge_space_from`이 사용되는지 확인.
+
+---
+
+## Task 1.4 — 재귀 깊이 설정
+
+MySQL 기본값 `cte_max_recursion_depth = 1000`은 충분하지만, 안전상 명시적 설정 권장:
+
+```sql
+SET SESSION cte_max_recursion_depth = 10;
+```
+
+최대 깊이 5에 충분하며, 데이터 이상 시 무한 루프를 빠르게 차단.
+
+[검증 필요] 적용 위치 결정:
+- (A) Hikari `connection-init-sql` (`spring.datasource.hikari.connection-init-sql`)
+- (B) 마이그레이션 스크립트의 GLOBAL 설정
+- (C) 메서드 호출 시점에 `JdbcTemplate.execute("SET SESSION ...")`
+
+(A)가 가장 안전 (모든 커넥션 적용, 운영 측 영향 없음).
+
+---
+
+## Task 1.5 — 단위 테스트
+
+테스트 위치: `api/src/test/java/com/mmt/api/repository/concept/MysqlConceptRepositoryCteTest.java`
+사용 인프라: M1의 Testcontainers MySQL + `application-test.yml` (ADR 0002 §2)
+
+테스트 케이스 (`findPrerequisiteConceptIds` 한정):
+
+- 단일 conceptId, depth 0 → 자기 자신 1개만 반환
+- depth 1 → 직접 선수 개념만 (자기 자신 포함)
+- depth N → N 단계 이내 모든 선수 개념
+- 존재하지 않는 conceptId → 빈 리스트
+- 깊이 매개변수가 음수 → IllegalArgumentException 또는 빈 리스트 (정책 결정 필요)
+- 다중 경로(같은 conceptId가 여러 깊이로 도달 가능) → DISTINCT로 중복 제거됨
+
+[검증 필요] 데이터에 순환 참조 존재 여부. 존재한다면 CTE는 `cte_max_recursion_depth`에 도달할 때까지 무한히 노드를 누적하므로 정확성 검증 케이스 추가 필수.
+
+객체 반환 메서드(`findPrerequisiteConcepts`)의 단위 테스트는 spec-02에서 추가.
+
+---
+
+## Task 1.6 — (이전: Concept 엔티티 매핑) — spec-02로 이전됨
+
+본 task는 객체 반환 메서드(`findPrerequisiteConcepts`)를 위한 `RowMapper<Concept>` 도입을 다뤘으나, 본 spec은 ID 반환 한정이므로 **spec-02로 이전**한다.
+
+매핑 정책은 ADR 0005(`concepts JOIN chapters` 패턴, conceptSection 매핑 생략, `Concept` 어노테이션은 spec-03 Task 5.3에서 일괄 정리)으로 확정. spec-02 Task 3.1에서 ConceptResponse 변환 분기와 함께 도입.
+
+---
+
+## 참조 데이터
+
+테스트는 M1에서 확보한 결과 스냅샷(`shared/benchmark/`)과 정확성 검증을 spec-03에서 수행한다. 본 spec의 단위 테스트는 격리된 작은 데이터셋을 사용한다.
+
+[검증 필요] M1에서 사용한 테스트 시드 데이터의 위치 및 형태. 동일 시드를 재활용할지, 본 spec 전용 시드를 작성할지 결정.
+
+---
+
+## 완료 기준
+
+- [ ] CTE 통합 메서드 1개 도입: `findPrerequisiteConceptIds(int, int)` — Stub을 실제 구현으로 대체 (편의 메서드 미도입 — Task 1.2)
+- [ ] 인덱스 3종 적용 (또는 기존재 시 검증 결과를 PR 설명에 명시)
+- [ ] `cte_max_recursion_depth` 설정 적용 위치 결정 및 반영
+- [ ] 단위 테스트 모두 통과 (Testcontainers 기반, ID 반환 메서드 한정)
+- [ ] 기존 `ConceptServiceFeatureFlagTest` 갱신 (Stub의 `UnsupportedOperationException` 검증을 실제 구현 동작 검증으로)
+- [ ] `EXPLAIN` 결과 PR 설명에 첨부
+- [ ] PR 설명에 ADR 0002 §3(Hibernate Statistics는 JPA 한정 — 본 spec은 JdbcTemplate이므로 비대상) 명시
+- [ ] Analyze-Before-Change 결과(영향받는 호출부, 롤백 시나리오) PR 설명 포함
+
+---
+
+## 비범위 (다른 spec에서 처리)
+
+- 객체 반환 그래프 메서드(`findNodesByConceptId`, `findToConcepts` 등) → spec-02 (ADR 0005의 `concepts JOIN chapters` 매핑 패턴 적용)
+- `RowMapper<Concept>` 도입 → spec-02
+- ConceptService 통합 → spec-02
+- 캐싱 적용 → spec-02
+- 피처 플래그 분기 → spec-02
+- 정확성 검증 (M1 스냅샷 대비) → spec-03
+- 성능 측정 → spec-03

--- a/docs/specs/m2/spec-02-service-integration-and-caching.md
+++ b/docs/specs/m2/spec-02-service-integration-and-caching.md
@@ -1,0 +1,306 @@
+# Spec 02: 서비스 통합 + 캐싱 + 리액티브 정리
+
+**상위 마일스톤:** Milestone 2 (Neo4j → MySQL CTE 마이그레이션)
+**대상 Phase:** Phase 2 + Phase 3
+**예상 소요:** 3일
+**선행 spec:** spec-01
+
+---
+
+## 범위
+
+spec-01에서 도입한 CTE 메서드를 ConceptService 그래프 메서드 군에 통합한다. 캐싱 레이어를 추가하고, 피처 플래그 기반 분기를 구현하며, Neo4j 제거 시 자연 해소되는 `.block()` 호출을 정리한다.
+
+본 spec은 **서비스 레이어에 한정**된다. 검증·점진 출시·폐기는 spec-03 범위.
+
+---
+
+## ⚠ 중요 — 피처 플래그 명명 정정
+
+원본 M2 자료의 `mmt.use-neo4j-for-graph` 표기는 다음 두 가지 문제가 있어 본 spec 전체에서 사용하지 않는다:
+
+1. **ADR 0002 §1 위반** — 영역 네임스페이스 누락 (`mmt.<영역>.<설정>` 2단계 위반)
+2. **의미 반전** — Neo4j를 OFF하는 플래그로 정의되어 직관성 저하
+
+M1에서 정착된 정식 키:
+
+```yaml
+mmt.migration.use-mysql-cte-for-graph: false   # 기본값 = 안전 측(Neo4j) fallback
+```
+
+- `true` → CTE 사용 (마이그레이션 진행)
+- `false` → Neo4j 사용 (기본값, 롤백 상태)
+- 본 spec과 spec-03 전체에서 이 키만 사용. 다른 표기 일체 금지.
+
+---
+
+## 사전 조건 / 검증 필요
+
+> 📌 **데이터 모델 의미 정의는 [spec-01의 데이터 모델 노트](spec-01-cte-repository-and-indexes.md#-데이터-모델-노트--knowledge_space-엣지-방향성) 참조.** `from_concept_id`=후수, `to_concept_id`=선수. 본 spec의 모든 SQL·캐시 키 의미는 이 정의를 따른다.
+
+- spec-01 완료 (CTE 메서드 사용 가능)
+- M1 산출물:
+  - 피처 플래그 `mmt.migration.use-mysql-cte-for-graph` 정의 완료
+  - `findNodesIdByConceptIdDepth3`에 분기 시범 적용 완료
+- ✓ Spring Cache 미도입 상태 확인 — `@EnableCaching`/`@Cacheable`/`@CacheEvict`/`RedisCacheManager`/`CacheManager` 모두 부재. Redis는 `RedisUtil`(`api/src/main/java/com/mmt/api/util/RedisUtil.java`)을 통한 직접 호출로만 사용 중(JWT 토큰 저장 용도). 본 spec의 Task 2.1은 ADR 0003에 따라 RedisUtil 직접 호출 패턴으로 진행한다.
+- ✓ M1 분기 패턴 확인 (`ConceptService.java:73-80`):
+  ```java
+  @Transactional(readOnly = true)
+  public Flux<Integer> findNodesIdByConceptIdDepth3(int conceptId){
+      if (useMysqlCte && mysqlConceptRepository.isPresent()) {
+          return Flux.fromIterable(
+              mysqlConceptRepository.get().findPrerequisiteConceptIds(conceptId, 3));
+      }
+      return conceptRepository.findNodesIdByConceptIdDepth3(conceptId);
+  }
+  ```
+  핵심 요소: ① `MysqlConceptRepository`(JdbcTemplate 아닌 별도 클래스) ② 통합 시그니처 `findPrerequisiteConceptIds(int, int)` ③ `Optional` 가드 `isPresent()` ④ `Flux.fromIterable` 래핑으로 시그니처 보존. 본 spec은 이 패턴을 다른 메서드에도 동일하게 확산한다.
+
+---
+
+## Task 2.1 — 캐싱 통합
+
+### 배경
+
+그래프 데이터는 읽기 전용 + CSV 초기 로드 후 변경 없음. 캐싱으로 CTE 성능 열세를 충분히 보상 가능.
+
+### 패턴: RedisUtil 직접 호출 (ADR 0003 결정)
+
+**ADR 0003에 따라 Spring Cache(`@Cacheable`/`RedisCacheManager`)를 도입하지 않고, 기존 `RedisUtil`(`api/src/main/java/com/mmt/api/util/RedisUtil.java`)을 직접 호출하는 패턴으로 캐싱을 구현한다.** `@EnableCaching` 선언, 빈 등록, SpEL `condition` 검증 등 인프라 작업은 모두 비대상.
+
+### 캐시 메서드 형태
+
+ConceptService(또는 별도 캐시 래퍼)에서 CTE 호출 직전·직후에 명시적으로 캐시 조회·저장:
+
+```java
+@Service
+public class ConceptService {
+
+    private final RedisUtil redisUtil;
+    private final Optional<MysqlConceptRepository> mysqlConceptRepository;
+    // RedisUtil.set(key, o, duration) 의 duration 은 MILLISECONDS 단위 (TimeUnit.MILLISECONDS).
+    // toSeconds() 사용 시 86.4초만 캐싱되어 의도(24h)와 불일치.
+    private static final long TTL_24H = Duration.ofHours(24).toMillis();
+
+    @Value("${mmt.migration.use-mysql-cte-for-graph:false}")
+    private boolean useMysqlCte;
+
+    @Transactional(readOnly = true)
+    public Flux<Integer> findNodesIdByConceptIdDepth3(int conceptId) {
+        if (useMysqlCte && mysqlConceptRepository.isPresent()) {
+            String key = "graph:prerequisites:ids:" + conceptId + ":3";
+            @SuppressWarnings("unchecked")
+            List<Integer> cached = (List<Integer>) redisUtil.get(key);
+            if (cached != null) return Flux.fromIterable(cached);
+
+            List<Integer> result = mysqlConceptRepository.get()
+                .findPrerequisiteConceptIds(conceptId, 3);
+            redisUtil.set(key, result, TTL_24H);
+            return Flux.fromIterable(result);
+        }
+        return conceptRepository.findNodesIdByConceptIdDepth3(conceptId);
+    }
+}
+```
+
+설계 메모:
+- 키 prefix 규약 (ADR 0003):
+  - `graph:prerequisites:ids:<conceptId>:<depth>` — `findPrerequisiteConceptIds` 결과
+  - `graph:prerequisites:objs:<conceptId>:<depth>` — `findPrerequisiteConcepts` 결과 (객체 반환)
+  - `graph:to-concepts:<conceptId>` — `findToConcepts` 결과 (depth=1 전용, `findPrerequisiteConcepts(?, 1)`과 동일)
+- **CTE 경로일 때만 캐시 적용** — Neo4j 경로는 캐시 미적용 (자체 그래프 인덱스 + 결과를 잘못 재사용할 위험 차단)
+- TTL 24시간 단일 (CSV 재로드 주기 ≥ 일 단위 가정 — Task 2.2)
+- 깊이를 키에 포함하여 depth 2/3/5 결과를 분리
+
+### 보일러플레이트 축소 (선택)
+
+if-else 6줄이 여러 메서드에 반복되므로 helper 메서드 1개로 축소 가능 (선택 사항):
+
+```java
+private <T> List<T> cachedOrCompute(String key, Supplier<List<T>> compute) {
+    @SuppressWarnings("unchecked")
+    List<T> cached = (List<T>) redisUtil.get(key);
+    if (cached != null) return cached;
+    List<T> result = compute.get();
+    redisUtil.set(key, result, TTL_24H);
+    return result;
+}
+```
+
+### 적용 대상 메서드
+
+Task 3.1의 분기 매트릭스에 등장하는 모든 CTE 분기에 동일 패턴 적용. 메서드별 키 prefix는 위 규약 따름.
+
+---
+
+## Task 2.2 — 캐시 TTL / 무효화
+
+- **TTL:** 24시간 (CSV 재로드 주기 ≥ 일 단위 가정)
+- **무효화 트리거:**
+  - 운영자 수동 무효화 endpoint (관리자 인증 필요) — `RedisUtil`에 prefix 기반 일괄 삭제 메서드를 추가하거나 `KEYS graph:*` + `DEL` (운영 환경 고려해 `SCAN` 권장)
+  - 자동 재로드 트리거 불필요 (CSV는 정적 데이터, 자동 적재 로직 부재 — audit 확인됨)
+
+검증 결과:
+- ✓ CSV 재로드 코드 자동화 **없음** — `ApplicationRunner`/`@Scheduled`/`csv` 관련 자동 적재 로직 grep 결과 0건. 결론: 운영자 수동 endpoint 1개만 구현하면 충분.
+- ✓ Spring Cache 추상화의 `allEntries = true` 동작 검토는 ADR 0003 결정에 따라 비대상 — `RedisUtil` 직접 호출 패턴이라 prefix 기반 삭제로 처리.
+
+---
+
+## Task 3.1 — 분기 적용
+
+### 대상 메서드 (M1 audit + spec-02 audit 확정)
+
+`ConceptService`만이 아니라 `KnowledgeSpaceService`도 `conceptRepository`(Neo4j)를 **직접** 호출(`KnowledgeSpaceService.java:29-34`)하므로 분기 대상에 포함한다.
+
+**ConceptService 메서드 (5개):**
+
+| 메서드 | 위치 | M1에서 분기 적용 | CTE 호출 형태 |
+|--------|------|------------------|----------------|
+| `findNodesByConceptId` | `ConceptService.java:57-63` | ✗ | 깊이 분기(이분: 초등=3, else=5) 그대로 두고 내부 두 호출 각각에 분기 |
+| `findNodesIdByConceptIdDepth2` | `ConceptService.java:66-68` | ✗ | `findPrerequisiteConceptIds(conceptId, 2)` |
+| `findNodesIdByConceptIdDepth3` | `ConceptService.java:73-80` | ✓ (시범) | `findPrerequisiteConceptIds(conceptId, 3)` |
+| `findNodesIdByConceptIdDepth5` | `ConceptService.java:81-84` | ✗ | `findPrerequisiteConceptIds(conceptId, 5)` |
+| `findToConcepts` | `ConceptService.java:52-53` | ✗ | spec-01의 `findPrerequisiteConcepts(conceptId, 1)` 호출로 처리 |
+
+**KnowledgeSpaceService 메서드 (2개 호출 지점):**
+
+| 호출 지점 | M1에서 분기 적용 | CTE 호출 형태 |
+|----------|------------------|----------------|
+| `KnowledgeSpaceService.java:33` (초등 → `findNodesIdByConceptIdDepth3`) | ✗ | `conceptRepository` 직접 호출 → ConceptService 경유로 변경하거나 동일 분기 적용 |
+| `KnowledgeSpaceService.java:34` (그 외 → `findNodesIdByConceptIdDepth5`) | ✗ | 위와 동일 |
+
+권장 — KnowledgeSpaceService를 `ConceptService.findNodesIdByConceptIdDepthN`을 경유하도록 리팩토링하면 ConceptService 5개 메서드의 분기가 자동 상속되어 KnowledgeSpaceService에 별도 분기 로직이 불필요. 본 spec 착수 시 채택 여부 결정.
+
+### 분기 패턴
+
+M1에서 `findNodesIdByConceptIdDepth3`에 적용한 패턴(`ConceptService.java:73-80`)을 표준으로 채택:
+
+```java
+@Value("${mmt.migration.use-mysql-cte-for-graph:false}")
+private boolean useMysqlCte;
+
+private final Optional<MysqlConceptRepository> mysqlConceptRepository;
+// ... 생성자 주입
+
+@Transactional(readOnly = true)
+public Flux<Integer> findNodesIdByConceptIdDepth3(int conceptId){
+    if (useMysqlCte && mysqlConceptRepository.isPresent()) {
+        return Flux.fromIterable(
+            mysqlConceptRepository.get().findPrerequisiteConceptIds(conceptId, 3));
+    }
+    return conceptRepository.findNodesIdByConceptIdDepth3(conceptId);
+}
+```
+
+핵심 요소:
+- 리포지토리: **`MysqlConceptRepository`** (M1에서 도입한 스텁, JdbcTemplate 아님)
+- 메서드 시그니처: **통합 형태** `findPrerequisiteConceptIds(int conceptId, int maxDepth)` (편의 메서드 미사용 — spec-01의 편의 메서드 도입 결정도 본 패턴에 맞춰 통합 단일로 통일 필요. spec-01 Task 1.2 참조)
+- Optional 가드 `isPresent()` 필수 — 플래그 false 상태에서는 bean 미존재
+- `Flux<T>` 반환 시 `Flux.fromIterable`로 동기 결과 래핑하여 시그니처 보존
+
+### `findToConcepts` 처리
+
+실제 Cypher (`ConceptRepository.java:13`):
+```cypher
+MATCH (n)-[r]->(m{concept_id: $conceptId}) RETURN (n)
+```
+
+[spec-01 데이터 모델 노트](spec-01-cte-repository-and-indexes.md#-데이터-모델-노트--knowledge_space-엣지-방향성)의 의미 정의에 따라, 이 Cypher는 "X의 직접 선수 1단계"를 반환. spec-01 Task 1.1의 쿼리 1과 동일하므로 **`findPrerequisiteConcepts(conceptId, 1)` 호출로 자연 처리**되며 별도 outgoing CTE 메서드 도입 불필요.
+
+호출처: `ConceptController.java:45` (REST 엔드포인트, 사용처 1곳).
+
+---
+
+## Task 3.2 — `.block()` 호출 정리
+
+### 식별된 위치 (전수 조사 완료)
+
+- ✓ `ProbabilityService.java:66` — `conceptIdFlux.collectList().block()` (M1 audit에서 식별)
+- ✓ `KnowledgeSpaceService.java:36` — `conceptIdFlux.distinct().collectList().block()` (spec-02 audit에서 추가 식별)
+
+전수 검증 명령:
+```bash
+grep -rn '\.block()' api/src/main/java/
+```
+본 spec 착수 시 위 명령을 재실행하여 누락 여부 재확인.
+
+### 처리 방향
+
+| 피처 플래그 상태 | 처리 |
+|------------------|------|
+| `true` (CTE) | CTE 메서드는 동기 반환 → `.block()` 호출 자체가 불필요해짐. 분기에서 자연 우회 |
+| `false` (Neo4j) | 기존 `.block()` 유지 (Neo4j Reactive 결과를 동기 호출부에 맞추기 위해 필요) |
+
+본 spec에서는 `.block()` 코드를 **삭제하지 않고**, 분기 분기점만 조정. Neo4j 완전 제거(spec-03 Task 5.3)에서 코드 자체 삭제.
+
+---
+
+## Task 3.3 — 학교 수준 분기 호환
+
+학교 수준 분기는 두 곳에 존재 (확정):
+
+- `ConceptService.java:57-63` (`findNodesByConceptId` 내부)
+- `KnowledgeSpaceService.java:29-34`
+
+매핑은 **이분**이며 동일한 패턴:
+```java
+String schoolLevel = jdbcTemplateConceptRepository.findSchoolLevelByConceptId(conceptId);
+if (schoolLevel.equals("초등")) → depth 3
+else                            → depth 5
+```
+
+CTE 경로에서도 동일 의미가 보존되어야 한다. Task 3.1의 분기 적용 시 깊이 3·5 두 메서드가 모두 분기되므로 `findNodesByConceptId`의 두 호출 라인이 자동으로 CTE/Neo4j 양쪽 경로를 가지게 된다. 별도 작업 불필요.
+
+KnowledgeSpaceService 측은 ConceptService 경유 리팩토링 채택 여부에 따라 분기되거나(직접 호출 유지 시) 자동 상속(경유 시) — Task 3.1 결정에 따른다.
+
+---
+
+## 테스트
+
+### 분기 동등성 테스트
+
+분기 양쪽 (`use-mysql-cte-for-graph: true | false`)에서 결과가 동등한지 검증:
+
+```java
+@SpringBootTest(properties = "mmt.migration.use-mysql-cte-for-graph=true")
+class ConceptServiceCteIntegrationTest { ... }
+
+@SpringBootTest(properties = "mmt.migration.use-mysql-cte-for-graph=false")
+class ConceptServiceNeo4jIntegrationTest { ... }
+```
+
+[검증 필요] M1에서 정착된 통합 테스트 패턴 (Testcontainers MySQL + Neo4j 동시 기동) 활용 가능 여부.
+
+### 캐시 동작 테스트
+
+- 동일 입력 2회 호출 → 2번째 호출은 리포지토리 미접근
+- 캐시 무효화 후 → 다시 리포지토리 접근
+- 피처 플래그 `false` (Neo4j) 경로 → 캐시 우회
+
+### N+1 회귀 검증
+
+ADR 0002 §3에 따라 Hibernate Statistics API로 N+1 회귀 확인 (JPA 리포지토리 한정). 본 spec의 변경은 JdbcTemplate 경로이므로 직접 영향 없으나, ConceptService에서 다른 JPA 리포지토리 호출이 변경 영향을 받지 않는지 확인.
+
+---
+
+## 완료 기준
+
+- [ ] 5개 그래프 메서드 모두 분기 적용 (또는 `findToConcepts` 제외 정책 명시)
+- [ ] 캐시 적용 (메서드별 키 prefix 분리)
+- [ ] CSV 재로드 시점 식별 + 무효화 경로 구현
+- [ ] `.block()` 호출 전수 목록 PR 설명에 첨부 (제거는 spec-03)
+- [ ] 분기 양쪽 통합 테스트 통과
+- [ ] 캐시 히트/미스 단위 테스트 통과
+- [ ] PR 설명에 분기 매트릭스(메서드 × 플래그 × 결과 동등성) 첨부
+- [ ] Analyze-Before-Change 결과(영향받는 호출부, 롤백 시나리오) PR 설명 포함
+
+---
+
+## 비범위 (다른 spec에서 처리)
+
+- CTE 메서드 자체 → spec-01
+- M1 스냅샷 대비 정확성 검증 → spec-03
+- 성능 측정 + 캐시 히트율 측정 → spec-03
+- Cytoscape.js / BFS 호환 검증 → spec-03
+- `.block()` 코드 삭제 → spec-03 Task 5.3
+- Neo4j 인프라 제거 → spec-03

--- a/docs/specs/m2/spec-03-validation-and-rollout.md
+++ b/docs/specs/m2/spec-03-validation-and-rollout.md
@@ -1,0 +1,254 @@
+# Spec 03: 검증 + 점진적 출시 + 폐기
+
+**상위 마일스톤:** Milestone 2 (Neo4j → MySQL CTE 마이그레이션)
+**대상 Phase:** Phase 4 + Phase 5
+**예상 소요:** 3일 (검증) + 운영 관찰 기간 (기본 1개월)
+**선행 spec:** spec-02
+
+---
+
+## 범위
+
+spec-01·02 산출물의 정확성·성능·호환성을 검증하고, 피처 플래그 기반 점진적 전환과 Neo4j 인프라 폐기를 수행한다.
+
+---
+
+## 사전 조건
+
+> 📌 **데이터 모델 의미 정의는 [spec-01의 데이터 모델 노트](spec-01-cte-repository-and-indexes.md#-데이터-모델-노트--knowledge_space-엣지-방향성) 참조.** `from_concept_id`=후수, `to_concept_id`=선수. 본 spec의 모든 검증·테스트 단정은 이 정의를 따른다.
+
+- spec-01·02 완료
+- M1 산출물 활용:
+  - 성능 기준선: `docs/benchmark/`
+  - Neo4j 결과 스냅샷 (sha256 해시 포함): `shared/benchmark/`
+  - QueryTimingAspect (Hibernate Statistics + SimpleMeterRegistry)
+
+---
+
+## Task 4.1 — 정확성 검증 (회귀)
+
+### 비교 전략 — unique 집합 기준
+
+M1 스냅샷의 `concept_ids` 배열은 Cypher `UNWIND nodes(path) AS node`로 만들어진 결과로 **경로 중복 포함**된 multiset이다(예: `conceptId=6646,depth=2` → count=37인데 unique 노드는 그보다 적음). M2 CTE는 `SELECT DISTINCT concept_id`로 평탄화한 unique 집합을 반환한다.
+
+따라서 두 결과는 **unique 노드 집합이 일치하면 의미적으로 동등**하며, multiset 직접 비교(`containsExactlyInAnyOrder`)나 sha256 raw 비교는 dedup 차이로 항상 실패한다. 비교는 다음 순서로 한다:
+
+1. **Set 등가 비교** (1차 게이트) — `Set.copyOf(snapshot.conceptIds)` vs `Set.copyOf(cteResult)`
+2. (선택) Set 기반 sha256 재계산 비교 — 정렬된 unique 리스트 문자열에 대해 양쪽이 동일 sha256을 산출하는지
+
+### 회귀 테스트 코드
+
+```java
+@Test
+void cteUniqueNodeSetMatchesNeo4jSnapshot() {
+    // 실제 스냅샷 구조: 단일 파일 + JSON 키 "conceptId=N,depth=D"
+    var snapshot = loadSnapshotEntry(
+        "shared/benchmark/neo4j-snapshot-20260424.json",
+        "conceptId=6646,depth=5");
+
+    Set<Integer> expected = Set.copyOf(snapshot.conceptIds);
+    Set<Integer> actual   = Set.copyOf(
+        mysqlConceptRepository.get().findPrerequisiteConceptIds(6646, 5));
+
+    assertThat(actual).isEqualTo(expected);
+
+    // (선택) sha256 재계산 비교 — 양쪽을 sorted unique 리스트로 정규화한 뒤 sha256
+    String expectedHash = sha256(new TreeSet<>(expected).toString());
+    String actualHash   = sha256(new TreeSet<>(actual).toString());
+    assertThat(actualHash).isEqualTo(expectedHash);
+}
+```
+
+검증된 사실 (audit 결과):
+- ✓ 스냅샷 위치/명명: `shared/benchmark/neo4j-snapshot-20260424.json` (단일 파일, 날짜 stamp 포함). JSON 최상위 키 = `"conceptId=N,depth=D"`, 값 = `{count, concept_ids[], sha256}`. **`concept_ids`는 multiset (UNWIND 결과 중복 포함), `count`는 multiset 길이**.
+- ✓ sha256 raw 값 (`api/src/test/java/com/mmt/api/performance/GraphQueryPerformanceTest.java:202, 232`)은 multiset 기반(`results.toString()`)이라 dedup된 CTE 결과와 직접 비교 불가. ⚠ `getBytes()`가 default charset에 의존하는 문제는 본 spec의 정규화 비교에서는 양쪽 모두 동일 charset에서 계산되므로 영향 없음.
+- ✓ 케이스 커버리지: 실제 스냅샷은 **깊이 2/3/5 × 다수 conceptId**(6646/7595/6420/6784/...) 9+ 케이스. 깊이 0/1 부재. 학교 수준별 분류 아님(특정 conceptId 선정).
+
+추가 검증:
+- ConceptService 분기 양쪽(use-mysql-cte true/false)이 동일 unique 집합에 일치하는지 (spec-02 통합 테스트와 중복 가능 — 위치 통합 검토).
+- 스냅샷에 conceptId=4979는 부재. select.sql:285 프로토타입의 하드코딩값과 다르므로, 회귀 테스트는 스냅샷 키에 존재하는 conceptId(예: 6646, 7595)를 사용한다.
+
+---
+
+## Task 4.2 — 성능 체크포인트
+
+| 항목 | 허용 기준 | 측정 방법 |
+|------|----------|----------|
+| CTE 깊이 3 (캐시 미스) | <30ms (p95) | SimpleMeterRegistry + `QueryTimingAspect` |
+| CTE 깊이 5 (캐시 미스) | <100ms (p95) | 동상 |
+| 캐시 히트 응답 시간 | <5ms | 동상 |
+| 캐시 히트율 (warm-up 후 1시간) | >90% | `RedisUtil` 카운터 추가 또는 로그 grep 집계 (ADR 0004) |
+
+> **측정 conceptId 일관성:** M1 baseline은 `conceptId=6646` 단일 ID로 측정됨(`docs/benchmark/milestone-1-baseline.md:40,52-56`). 본 task의 CTE 측정·부하 테스트도 **동일 conceptId(6646)** 를 사용하여 깊이별·경로별 비교가 의미를 가지도록 한다. 추가 ID(7595/6420/6784)는 회귀 보강 케이스로 활용.
+
+### 부하 테스트 시나리오
+
+- ✓ k6 인프라 가용 (`shared/performance-tests/test_concepts_by_chapter.js`, `test_item_by_concept.js`, `k6_docker_commands.sh`). 단 **그래프 쿼리 전용 시나리오는 부재** → 본 spec에서 신규 작성 (예: `test_graph_prerequisite_by_depth.js`).
+- conceptId=6646 고정, 깊이 3·5 각각 1,000회 호출, p50/p95/p99 측정
+- 캐시 비활성 / 활성 두 조건 비교
+
+### 모니터링 인프라 결정 (ADR 0004에 따라 확정)
+
+ADR 0004에 따라 production 모니터링 인프라(Prometheus + Grafana + Actuator)는 **M3로 분리**한다. 본 spec은 다음만 수행:
+
+- M1의 `SimpleMeterRegistry` + `QueryTimingAspect` 슬로우 쿼리 WARN 로그로 검증 단계 측정
+- 부하 테스트 결과·메트릭 dump를 PR 설명에 첨부
+- 캐시 히트율은 `RedisUtil`에 카운터 추가 또는 로그 기반 집계로 우회
+
+dashboard·alerting은 비범위.
+
+---
+
+## Task 4.3 — Cytoscape.js 호환
+
+- **대상:** `web/`의 그래프 시각화 컴포넌트가 받는 백엔드 응답
+- **검증:** 분기 양쪽에서 응답 DTO의 직렬화 결과가 동일한지 비교
+
+```java
+@Test
+void cytoscapeResponseDtoIsIdentical() {
+    var neo4jResponse = serviceWithFlag(false).getGraphForVisualization(...);
+    var cteResponse   = serviceWithFlag(true).getGraphForVisualization(...);
+    assertThat(toJson(cteResponse)).isEqualTo(toJson(neo4jResponse));
+}
+```
+
+검증 결과:
+- ✓ 활성 응답 DTO: `ConceptResponse` (`ConceptConverter.convertToFluxConceptResponse` 경유, `findNodesByConceptId`/`findToConcepts`가 `Flux<ConceptResponse>` 반환). `NodeResponse`/`NetworkResponse`는 `ConceptService.java:98-109`의 주석 처리 코드에만 존재 (활성 미사용).
+- DTO 구조: `Concept` 도메인을 그대로 변환 (concept_id 등 노드 정보). **엣지 정보는 별도 조회**가 필요 — 본 spec에서 응답 동등성 비교 시 엣지 조회 경로도 검증 대상에 포함.
+- 프론트 컴포넌트: `web/src/views/ResultView.vue`, `web/src/views/ConceptView.vue`에서 `cytoscape` + `cytoscape-klay`로 그래프 렌더링. cytoscape 변환 로직은 프론트 측에 위치하므로 백엔드 응답이 동일하면 시각화 동작 보장.
+
+---
+
+## Task 4.4 — BFS 호환
+
+- **대상:** `LogicUtil.bfs(int start, List<Integer> integerList) → Map<Integer, Integer>` (거리 맵)
+- **검증:** 분기 양쪽에서 동일한 거리 맵 산출
+
+```java
+@Test
+void bfsResultIsIdenticalAcrossBranches() {
+    // 실제 BFS 호출처(ProbabilityService.java:65-68)와 동일하게 깊이 3 사용
+    int conceptId = 6646;  // 스냅샷 키에 존재
+    var neo4jIds = serviceWithFlag(false).findNodesIdByConceptIdDepth3(conceptId);
+    var cteIds   = serviceWithFlag(true).findNodesIdByConceptIdDepth3(conceptId);
+
+    var neo4jBfs = LogicUtil.bfs(conceptId, neo4jIds.collectList().block());
+    var cteBfs   = LogicUtil.bfs(conceptId, cteIds.collectList().block());
+
+    assertThat(cteBfs).isEqualTo(neo4jBfs);
+}
+```
+
+검증된 사실:
+- ✓ BFS 입력 출처: `ProbabilityService.java:65-68`에서 `conceptService.findNodesIdByConceptIdDepth3(conceptId).collectList().block()` 결과를 BFS에 투입. 즉 **`findNodesIdByConceptIdDepth3` 결과 ID 리스트**가 표준 입력. 깊이 5는 BFS에 사용되지 않음.
+- BFS 입력 ID 집합의 의미: 시작 conceptId 자기 자신 + 그 선수 개념을 깊이 3까지 거슬러 올라간 노드들. 시작 노드가 입력에 포함되므로 거리 맵 key 집합도 시작 노드 + 선수들이다. 의미 정의는 [spec-01 데이터 모델 노트](spec-01-cte-repository-and-indexes.md#-데이터-모델-노트--knowledge_space-엣지-방향성) 참조 — spec 실행 시 시드 데이터로 한 번 더 검증 권장.
+- BFS 결과 거리 맵: key = 입력 리스트 내 conceptId, value = `start`로부터의 최단 거리. 빠진 노드가 있을 경우 동작은 `LogicUtil.bfs` 구현 확인 후 동등성 검증 케이스에 추가 (입력 리스트가 같다면 동일한 거리 맵이 보장됨).
+
+깊이 5 회귀 보강은 별도 케이스로 추가하되 주 검증 깊이는 3으로 한다.
+
+---
+
+## Task 5.1 — 점진적 트래픽 전환
+
+원본 M2 자료의 "10% → 50% → 100% 전환"은 멀티 인스턴스 + 로드 밸런서 환경 가정. 현재 MMT 배포 구조 확인 후 다음 중 채택:
+
+| 옵션 | 조건 | 방법 |
+|------|------|------|
+| (A) LB 분할 | 멀티 인스턴스 환경 | 인스턴스별로 피처 플래그를 다르게 설정해 트래픽 비율 조절 |
+| (B) 서비스 레이어 % 분할 | 단일 인스턴스 | conceptId 또는 사용자 ID 해싱(`hash % 100 < threshold`)으로 % 기반 분기. 피처 플래그를 boolean에서 percentage로 확장 |
+| (C) 즉시 전환 + 관찰 연장 | 단일 인스턴스 | 카나리 없이 ON/OFF만, 대신 관찰 기간 1개월 → 2주 + 빠른 롤백 준비 |
+
+**채택: (C) 즉시 전환 + 관찰 연장.** 단일 인스턴스 환경 + 정적 데이터 + 즉시 롤백 가능 + 영향 범위 제한적이라는 조건이 모두 (C)에 부합. (A)는 인프라 부재로 불가, (B)는 정적 그래프 데이터에서 % 분할의 의미가 약함(같은 conceptId 입력이 사용자에 따라 다른 결과를 낼 이유 없음).
+
+본 채택은 **별도 ADR로 기록**한다(번호 0006 또는 후속 마일스톤 ADR 묶음의 일부). ADR 작성 사유: 향후 다른 마이그레이션·기능 출시에서 동일 단일 인스턴스 조건이라면 (C) 정책을 재사용 가능하므로 일회성 결정이 아니라 정책 기록.
+
+[검증 필요] 현재 배포 환경 최종 확인: AWS 인스턴스 수, LB 사용 여부, 배포 자동화 도구. 멀티 인스턴스로 판명되면 채택을 (A)로 변경 후 ADR 갱신.
+
+---
+
+## Task 5.2 — 모니터링 항목
+
+| 지표 | 목표 | 수집 위치 |
+|------|------|----------|
+| CTE 경로 에러율 | 0% | [검증 필요] 에러 로그 집계 |
+| CTE 응답 시간 (p95) | Task 4.2 기준 충족 | QueryTimingAspect 로그 |
+| 캐시 히트율 | >90% | `RedisUtil` 카운터 또는 로그 집계 (ADR 0003 + ADR 0004) |
+| 진단 결과 페이지 로드 시간 | 회귀 없음 (M1 기준선 대비) | 프론트 측 측정 — [검증 필요: 운영자] 측정 도구·환경 확인 |
+| 그래프 시각화 렌더링 정상 여부 | 100% | 프론트 에러 로그 — [검증 필요: 운영자] 로그 인프라 확인 |
+
+ADR 0004에 따라 production 메트릭 dashboard·alerting은 비범위. 본 task의 지표 수집은 모두 로그 기반 + `RedisUtil` 카운터로 우회.
+
+---
+
+## Task 5.3 — Neo4j 폐기 체크리스트
+
+관찰 기간 무사고 후 다음 항목 순차 진행. 각 항목은 별도 커밋(루트 CLAUDE.md "커밋은 Task 단위" 규칙).
+
+### 코드 / 설정 정리
+
+- [ ] 피처 플래그 분기 코드 단순화 (CTE 직접 호출, `if (useMysqlCte && mysqlConceptRepository.isPresent())` 분기 제거)
+- [ ] `.block()` 잔존 호출 제거 (spec-02 Task 3.2 후속) — 위치: `ProbabilityService.java:66`, `KnowledgeSpaceService.java:36`
+- [ ] ✓ 삭제 대상 클래스: **`ConceptRepository`** (`api/src/main/java/com/mmt/api/repository/concept/ConceptRepository.java`, `extends ReactiveNeo4jRepository<Concept, Integer>`)
+- [ ] Neo4j 도메인 엔티티 삭제: `Concept.java:9`의 `@Node("concept")` 어노테이션. M2 이후 MySQL 전용 엔티티로 단순화 (또는 신규 JPA 엔티티 도입)
+- [ ] ✓ 의존성 제거: `org.springframework.boot:spring-boot-starter-data-neo4j` (`build.gradle:31`) **+ `org.testcontainers:neo4j` 테스트 의존성 (`build.gradle:62`)**
+- [ ] 공용 `application.yml`·`application-test.yml`의 Neo4j 관련 logging level 제거 (`logging.level...neo4j: DEBUG`, `org.springframework.data.neo4j.cypher: DEBUG`). `application-securelocal.yml`은 gitignored이므로 운영자가 수동으로 Neo4j 연결 설정 제거. **공용 yml에 `spring.neo4j.*` 블록은 부재**(이미 정리된 상태) — 별도 작업 불필요
+- [ ] 피처 플래그 `mmt.migration.use-mysql-cte-for-graph` 제거 (분기 사라졌으므로) + `MysqlConceptRepository`의 `@ConditionalOnProperty` 제거
+
+### 인프라 정리
+
+- [ ] `docker-compose.yml`에서 `mmt-neo4j` 컨테이너 제거 — **ADR 작성 필수** (루트 CLAUDE.md "docker-compose.yml의 서비스 구성은 ADR 없이 변경 금지")
+- [ ] [검증 필요] AWS Neo4j 인스턴스 종료 — 운영 권한 보유자 확인
+- [ ] Neo4j 커스텀 Docker 이미지(`mymathteacher/mmt-neo4j:1.0.0`) Docker Hub 정리 정책 결정 (즉시 삭제 / 보관)
+
+### M1 산출물 정리
+
+- [ ] M1에서 추가한 Testcontainers Neo4j 설정 제거 (테스트 시간 단축)
+- [ ] M1 결과 스냅샷(`shared/benchmark/`)은 회귀 검증 자료로 **유지** (재마이그레이션 시 참조)
+
+### 문서
+
+- [ ] Neo4j 도입 배경(v1)과 폐기 사유(M2)를 함께 기록한 ADR 작성
+- [ ] 루트 CLAUDE.md 업데이트: 모노레포 구조에서 `neo4j/` 디렉토리의 위상 변경 (또는 디렉토리 삭제)
+- [ ] `docs/roadmap.md`에서 M2 완료 표시
+
+### 롤백 안전망
+
+- [ ] 컨테이너 제거 전 마지막 단계: 1 릴리즈 주기 동안 Neo4j 컨테이너를 docker-compose 주석 처리만 해두고 코드는 살려둠
+- [ ] [검증 필요] "1 릴리즈 주기"의 정의. 프로젝트의 릴리즈 주기 규약이 없다면 캘린더 기반(예: 14일)으로 고정
+
+**중간 롤백 시나리오:**
+- 컨테이너 제거 전: 피처 플래그 `false`로 즉시 복귀
+- 컨테이너 제거 후 코드 잔존: docker-compose 주석 해제 + 코드 revert
+- 코드 제거 후: git revert 커밋 후 재빌드·재배포 (~30분)
+
+---
+
+## 완료 기준
+
+- [ ] Task 4.1~4.4 모두 통과
+- [ ] Task 5.1 채택안 (C) 실행 완료 + ADR 기록
+- [ ] 관찰 기간 무사고 (기본 1개월, [검증 필요] 단축/연장 기준)
+- [ ] Task 5.3 체크리스트 모두 완료
+- [ ] Neo4j 폐기 ADR 작성
+- [ ] 루트 CLAUDE.md / roadmap.md 업데이트
+
+---
+
+## 비범위 (다른 spec/마일스톤에서 처리)
+
+- CTE 메서드 자체 → spec-01
+- 캐싱 / 분기 / `.block()` 정리 → spec-02
+- production 모니터링 인프라 (Prometheus·Grafana, dashboard, alerting) → **M3로 분리 (ADR 0004)**
+
+---
+
+## 참조
+
+- ADR 0001: 마이그레이션 전 테스트 커버리지 선행 구축
+- ADR 0002 §3: Hibernate Statistics 기반 N+1 검증 (JPA 한정)
+- ADR 0003: M2 캐싱 패턴 (RedisUtil 직접 호출)
+- ADR 0004: M2 모니터링 인프라 M3 분리
+- ADR 0005: CTE 객체 반환 메서드 도메인 매핑
+- spec-01 데이터 모델 노트 (`knowledge_space` 엣지 방향성)
+- M1 산출물: `docs/benchmark/milestone-1-baseline.md`, `shared/benchmark/neo4j-snapshot-20260424.json`


### PR DESCRIPTION
## Summary

- spec-03 검증 중 발견: 이전 main의 ADR 0003은 `knowledge_space (from, to)` 의미를 `from=선수, to=후수`로 해석했으나, Neo4j 로드 코드 + Cypher 쿼리 의미는 `from=후수, to=선수`가 옳음
- 잘못된 해석 위에 spec-01 + spec-02 구현이 쌓여 전체 M2를 `ea0036d`(M2 활성화 직후, ADR 0003 작성 직전)로 force-reset 후 정정 docs로 재시작
- 이 PR은 정정된 8개 docs(milestone, spec-01/02/03, ADR 0003/0004/0005 + evidence)를 새로 도입

## 핵심 변경점

- **spec-01 데이터 모델 노트** 신설: `from=후수, to=선수` 명시 + Neo4j 로드 코드·Cypher 의미·mermaid trace 근거 첨부
- **ADR 0003** M2 캐싱 패턴 (RedisUtil 직접 호출, Spring Cache 미도입)
- **ADR 0004** M2 모니터링 인프라는 M3로 분리
- **ADR 0005** CTE 객체 반환 매핑 (`concepts JOIN chapters`) + evidence 보조 자료
- **spec-03 Task 4.1** Cypher path UNWIND가 multiset이므로 Set 등가 비교 채택
- **spec-03 Task 5.1** 옵션 C(즉시 전환 + 관찰 연장) 채택 명시

## Test plan

- [ ] docs 빌드: 마크다운 링크/경로 검증 (수동)
- [ ] /audit-doc 으로 spec-01/02/03 + ADR 0003~0005 정합성 점검
- [ ] 머지 후 spec-01 redo 착수

🤖 Generated with [Claude Code](https://claude.com/claude-code)