### PR TITLE
docs: drop time estimates from m0/m1 doc headers

### DIFF
--- a/docs/milestones/milestone-0-claude-code-integration.md
+++ b/docs/milestones/milestone-0-claude-code-integration.md
@@ -1,7 +1,6 @@
 # Milestone 0: Claude Code 통합 환경 구축
 
 **브랜치:** `chore/setup-claude-code-integration`
-**예상 소요:** 1.5~2일
 **의존성:** 없음
 **위험 수준:** 매우 낮음
 

--- a/docs/milestones/milestone-1-test-infrastructure.md
+++ b/docs/milestones/milestone-1-test-infrastructure.md
@@ -1,7 +1,6 @@
 # Milestone 1: 테스트 인프라 및 기준선 구축
 
 **브랜치:** `chore/setup-test-infrastructure`
-**예상 소요:** 3일
 **의존성:** Milestone 0 완료 (CLAUDE.md 계층·슬래시 커맨드·가드레일)
 **위험 수준:** 낮음
 **관련 ADR:** [ADR 0001: 마이그레이션 전 테스트 커버리지 선행 구축](../adr/0001-test-coverage-before-migration.md)

--- a/docs/specs/m0/spec-01-project-context.md
+++ b/docs/specs/m0/spec-01-project-context.md
@@ -2,7 +2,6 @@
 
 **상위 마일스톤:** [Milestone 0](../../milestones/milestone-0-claude-code-integration.md)
 **브랜치:** `chore/setup-claude-code-integration`
-**예상 Claude Code 세션:** 1회 (45~60분)
 
 ---
 

--- a/docs/specs/m0/spec-02-workflow-and-commands.md
+++ b/docs/specs/m0/spec-02-workflow-and-commands.md
@@ -2,7 +2,6 @@
 
 **상위 마일스톤:** [Milestone 0](../../milestones/milestone-0-claude-code-integration.md)
 **브랜치:** `chore/setup-claude-code-integration`
-**예상 Claude Code 세션:** 1회 (30~45분)
 **선행 Spec:** [spec-01-project-context.md](spec-01-project-context.md) 완료 필수
 
 ---

--- a/docs/specs/m0/spec-03-guardrails-and-verification.md
+++ b/docs/specs/m0/spec-03-guardrails-and-verification.md
@@ -2,7 +2,6 @@
 
 **상위 마일스톤:** [Milestone 0](../../milestones/milestone-0-claude-code-integration.md)
 **브랜치:** `chore/setup-claude-code-integration`
-**예상 Claude Code 세션:** 1회 (30분)
 **선행 Spec:** [spec-01-project-context.md](spec-01-project-context.md), [spec-02-workflow-and-commands.md](spec-02-workflow-and-commands.md) 완료 필수
 
 ---

--- a/docs/specs/m1/spec-01-testcontainers-and-integration-tests.md
+++ b/docs/specs/m1/spec-01-testcontainers-and-integration-tests.md
@@ -2,7 +2,6 @@
 
 **상위 마일스톤:** [Milestone 1](../../milestones/milestone-1-test-infrastructure.md)
 **브랜치:** `chore/setup-test-infrastructure`
-**예상 Claude Code 세션:** 2회 (90~120분)
 **선행 조건:** Milestone 0 완료, ADR `0001-test-coverage-before-migration.md` Accepted
 
 ---

--- a/docs/specs/m1/spec-02-performance-baseline.md
+++ b/docs/specs/m1/spec-02-performance-baseline.md
@@ -2,7 +2,6 @@
 
 **상위 마일스톤:** [Milestone 1](../../milestones/milestone-1-test-infrastructure.md)
 **브랜치:** `chore/setup-test-infrastructure`
-**예상 Claude Code 세션:** 1회 (60분)
 **선행 Spec:** [spec-01-testcontainers-and-integration-tests.md](spec-01-testcontainers-and-integration-tests.md) 완료 필수
 
 ---

--- a/docs/specs/m1/spec-03-feature-flags-and-observability.md
+++ b/docs/specs/m1/spec-03-feature-flags-and-observability.md
@@ -2,7 +2,6 @@
 
 **상위 마일스톤:** [Milestone 1](../../milestones/milestone-1-test-infrastructure.md)
 **브랜치:** `chore/setup-test-infrastructure`
-**예상 Claude Code 세션:** 1회 (60분)
 **선행 Spec:** [spec-02-performance-baseline.md](spec-02-performance-baseline.md) 완료 필수
 
 ---


### PR DESCRIPTION
## Summary

자가 추정 시간 수치(`예상 소요`, `예상 Claude Code 세션`)는 1인 프로젝트에서 의미가 약하고 stale되기 쉬워 M0/M1 마일스톤·spec 헤더에서 일괄 제거.

- M0 마일스톤: `예상 소요: 1.5~2일` 제거
- M1 마일스톤: `예상 소요: 3일` 제거
- M0 specs 3종: `예상 Claude Code 세션: N회 (XX~XX분)` 제거
- M1 specs 3종: `예상 Claude Code 세션: N회 (XX~XX분)` 제거

M2 docs는 같은 맥락으로 PR #18에서 정리 (별도 커밋 `e3ecf9e`).

## Test plan

- [ ] 헤더 외 본문 의미 변화 없음 확인 (단순 라인 삭제만)
- [ ] PR #18과 충돌 없음 확인 (서로 다른 파일 영향)

🤖 Generated with [Claude Code](https://claude.com/claude-code)